### PR TITLE
Changing ddLogInfo to be managed at the file level.

### DIFF
--- a/WordPress-iOS-Shared/Exclude/WordPressShared.m
+++ b/WordPress-iOS-Shared/Exclude/WordPressShared.m
@@ -1,7 +1,5 @@
 #import "WordPressShared.h"
 
-int ddLogLevel = LOG_LEVEL_INFO;
-
 @implementation WordPressShared
 
 

--- a/WordPress-iOS-Shared/WPFontManager.m
+++ b/WordPress-iOS-Shared/WPFontManager.m
@@ -1,6 +1,8 @@
 #import "WPFontManager.h"
 #import <CoreText/CoreText.h>
 
+static int ddLogLevel = LOG_LEVEL_INFO;
+
 @implementation WPFontManager
 
 static NSString * const kBundle = @"WordPress-iOS-Shared.bundle";

--- a/WordPress-iOS-Shared/WPImageSource.m
+++ b/WordPress-iOS-Shared/WPImageSource.m
@@ -3,6 +3,8 @@
 
 #import "WPAnimatedImageResponseSerializer.h"
 
+static int ddLogLevel = LOG_LEVEL_INFO;
+
 NSString * const WPImageSourceErrorDomain = @"WPImageSourceErrorDomain";
 
 @implementation WPImageSource {

--- a/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
+++ b/WordPress-iOS-Shared/WordPress-iOS-Shared-Prefix.pch
@@ -8,8 +8,6 @@
     #import <UIKit/UIKit.h>
     #import "DDLog.h"
 
-extern int ddLogLevel;
-
 #ifndef IS_IPAD
 #define IS_IPAD   ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #endif


### PR DESCRIPTION
Having it at a more global state like this was causing problems when you would try to add this library as a pod to a blank project.
