### PR TITLE
Fix header and footer width/height calculation

### DIFF
--- a/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h
@@ -4,11 +4,18 @@
 
 @property (nonatomic, strong) NSString *title;
 
-// By default, the title is flush left. Setting a fixed
-// width places the title flush left within the specified width.
-// Specified width must be greater than 0.
-@property (nonatomic, assign) CGFloat fixedWidth;
+// By default, fixedWidth will be enabled, which means for iPads
+// the title label width will be <= WPTableViewFixedWidth. There
+// will be equal padding before and after the label, if you want the label
+// to have a default padding and a full width instead, you can disable the fixedWidth flag.
+@property (nonatomic) BOOL fixedWidthEnabled;
 
+// By default, fixedWidth flag will assumed to be enabled and the title label width
+// will be treated for <= WPTableViewFixedWidth for iPads.
 + (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width;
+
+// If you disable the fixedWidth flag for the instance, you should pass `NO` as the
+// fixedWidthEnabled parameter, so it will use the full width for the calculation
++ (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width fixedWidthEnabled:(BOOL)fixedWidthEnabled;
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m
@@ -3,16 +3,15 @@
 #import "WPStyleGuide.h"
 #import "NSString+Util.h"
 
-@interface WPTableViewSectionFooterView() {
-    UILabel *_titleLabel;
-}
+@interface WPTableViewSectionFooterView ()
+
+@property (nonatomic, strong) UILabel *titleLabel;
 
 @end
 
 CGFloat const WPTableViewSectionFooterViewStandardOffset = 16.0;
 CGFloat const WPTableViewSectionFooterViewTopVerticalPadding = 21.0;
 CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 8.0;
-
 
 @implementation WPTableViewSectionFooterView
 
@@ -29,8 +28,10 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 8.0;
         _titleLabel.textColor = [WPStyleGuide allTAllShadeGrey];
         _titleLabel.backgroundColor = [UIColor clearColor];
         _titleLabel.shadowOffset = CGSizeMake(0.0, 0.0);
-        _fixedWidth = IS_IPAD ? WPTableViewFixedWidth : 0.0;
         [self addSubview:_titleLabel];
+
+        // fixed width should be enabled by default
+        _fixedWidthEnabled = YES;
     }
     return self;
 }
@@ -38,7 +39,7 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 8.0;
 - (void)setTitle:(NSString *)title
 {
     _title = title;
-    _titleLabel.text = _title;
+    self.titleLabel.text = _title;
     [self setNeedsLayout];
 }
 
@@ -46,30 +47,50 @@ CGFloat const WPTableViewSectionFooterViewBottomVerticalPadding = 8.0;
 {
     [super layoutSubviews];
 
-    CGFloat width = CGRectGetWidth(self.bounds);
-    if (self.fixedWidth > 0) {
-        width = MIN(self.fixedWidth, width);
-    }
-    
-    CGSize titleSize = [[self class] sizeForTitle:_titleLabel.text andWidth:CGRectGetWidth(self.bounds)];
-    _titleLabel.frame = CGRectIntegral(CGRectMake(WPTableViewSectionFooterViewStandardOffset + (CGRectGetWidth(self.superview.frame) - width) / 2.0, WPTableViewSectionFooterViewTopVerticalPadding, width, titleSize.height));
+    CGFloat sectionWidth = CGRectGetWidth(self.bounds);
+    CGFloat titleWidth = [[self class] titleLabelWidthFromSectionWidth:sectionWidth fixedWidthEnabled:self.fixedWidthEnabled];
+    CGSize titleSize = [[self class] sizeForTitle:self.titleLabel.text andTitleWidth:titleWidth];
+    CGFloat padding = (sectionWidth - titleWidth) / 2.0;
+
+    self.titleLabel.frame = CGRectIntegral(CGRectMake(padding, WPTableViewSectionFooterViewTopVerticalPadding, titleWidth, titleSize.height));
 }
 
+// fixedWidth is enabled by default
 + (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width
 {
-    if ([title length] == 0)
+    return [self heightForTitle:title andWidth:width fixedWidthEnabled:YES];
+}
+
++ (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width fixedWidthEnabled:(BOOL)fixedWidthEnabled
+{
+    if ([title length] == 0) {
         return 0.0;
-    
-    return [self sizeForTitle:title andWidth:width].height + WPTableViewSectionFooterViewTopVerticalPadding + WPTableViewSectionFooterViewBottomVerticalPadding;
+    }
+
+    CGFloat titleWidth = [[self class] titleLabelWidthFromSectionWidth:width fixedWidthEnabled:fixedWidthEnabled];
+    return [self sizeForTitle:title andTitleWidth:titleWidth].height + WPTableViewSectionFooterViewTopVerticalPadding + WPTableViewSectionFooterViewBottomVerticalPadding;
 }
 
 #pragma mark - Private Methods
 
-+ (CGSize)sizeForTitle:(NSString *)title andWidth:(CGFloat)width
++ (CGSize)sizeForTitle:(NSString *)title andTitleWidth:(CGFloat)titleWidth
 {
-    CGFloat titleWidth = width - 2 * WPTableViewSectionFooterViewStandardOffset;
-    return [title suggestedSizeWithFont:[WPStyleGuide subtitleFont] width:titleWidth];
+    return [title suggestedSizeWithFont:[WPStyleGuide tableviewSectionHeaderFont] width:titleWidth];
 }
 
++ (CGFloat)titleLabelWidthFromSectionWidth:(CGFloat)sectionWidth fixedWidthEnabled:(BOOL)fixedWidthEnabled
+{
+    CGFloat titleLabelWidth = sectionWidth;
+    CGFloat fixedWidth = [[self class] fixedWidth];
+    if (fixedWidthEnabled && fixedWidth > 0) {
+        titleLabelWidth = MIN(fixedWidth, titleLabelWidth);
+    }
+    return titleLabelWidth - (2 * WPTableViewSectionFooterViewStandardOffset);
+}
+
++ (CGFloat)fixedWidth
+{
+    return IS_IPAD ? WPTableViewFixedWidth : 0.0;
+}
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.h
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.h
@@ -4,11 +4,18 @@
 
 @property (nonatomic, strong) NSString *title;
 
-// By default, the title is flush left. Setting a fixed
-// width places the title flush left within the specified width.
-// Specified width must be greater than 0.
-@property (nonatomic, assign) CGFloat fixedWidth;
+// By default, fixedWidth will be enabled, which means for iPads
+// the title label width will be <= WPTableViewFixedWidth. There
+// will be equal padding before and after the label, if you want the label
+// to have a default padding and a full width instead, you can disable the fixedWidth flag.
+@property (nonatomic) BOOL fixedWidthEnabled;
 
+// By default, fixedWidth flag will assumed to be enabled and the title label width
+// will be treated for <= WPTableViewFixedWidth for iPads.
 + (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width;
+
+// If you disable the fixedWidth flag for the instance, you should pass `NO` as the
+// fixedWidthEnabled parameter, so it will use the full width for the calculation
++ (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width fixedWidthEnabled:(BOOL)fixedWidthEnabled;
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m
@@ -3,17 +3,17 @@
 #import "WPStyleGuide.h"
 #import "NSString+Util.h"
 
-@interface WPTableViewSectionHeaderView() {
-    UILabel *_titleLabel;
-}
+@interface WPTableViewSectionHeaderView ()
+
+@property (nonatomic, strong) UILabel *titleLabel;
 
 @end
-
-@implementation WPTableViewSectionHeaderView
 
 CGFloat const WPTableViewSectionHeaderViewStandardOffset = 16.0;
 CGFloat const WPTableViewSectionHeaderViewTopVerticalPadding = 21.0;
 CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
+
+@implementation WPTableViewSectionHeaderView
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -27,8 +27,10 @@ CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
         _titleLabel.textColor = [WPStyleGuide whisperGrey];
         _titleLabel.backgroundColor = [UIColor clearColor];
         _titleLabel.shadowOffset = CGSizeMake(0.0, 0.0);
-        _fixedWidth = IS_IPAD ? WPTableViewFixedWidth : 0.0;
         [self addSubview:_titleLabel];
+
+        // fixed width should be enabled by default
+        _fixedWidthEnabled = YES;
     }
     return self;
 }
@@ -36,36 +38,58 @@ CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
 - (void)setTitle:(NSString *)title
 {
     _title = [title uppercaseString];
-    _titleLabel.text = _title;
+    self.titleLabel.text = _title;
     [self setNeedsLayout];
 }
 
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    
-    CGFloat width = CGRectGetWidth(self.superview.frame);
-    if (self.fixedWidth > 0) {
-        width = MIN(self.fixedWidth, width);
-    }
-    CGSize titleSize = [[self class] sizeForTitle:_titleLabel.text andWidth:CGRectGetWidth(self.bounds)];
-    _titleLabel.frame = CGRectIntegral(CGRectMake(WPTableViewSectionHeaderViewStandardOffset + (CGRectGetWidth(self.superview.frame) - width) / 2.0, WPTableViewSectionHeaderViewTopVerticalPadding, width, titleSize.height));
+
+    CGFloat sectionWidth = CGRectGetWidth(self.bounds);
+    CGFloat titleWidth = [[self class] titleLabelWidthFromSectionWidth:sectionWidth fixedWidthEnabled:self.fixedWidthEnabled];
+    CGSize titleSize = [[self class] sizeForTitle:self.titleLabel.text andTitleWidth:titleWidth];
+    CGFloat padding = (sectionWidth - titleWidth) / 2.0;
+
+    self.titleLabel.frame = CGRectIntegral(CGRectMake(padding, WPTableViewSectionHeaderViewTopVerticalPadding, titleWidth, titleSize.height));
 }
 
+// fixedWidth is enabled by default
 + (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width
 {
-    if ([title length] == 0)
+    return [self heightForTitle:title andWidth:width fixedWidthEnabled:YES];
+}
+
++ (CGFloat)heightForTitle:(NSString *)title andWidth:(CGFloat)width fixedWidthEnabled:(BOOL)fixedWidthEnabled
+{
+    if ([title length] == 0) {
         return 0.0;
-    
-    return [self sizeForTitle:title andWidth:width].height + WPTableViewSectionHeaderViewTopVerticalPadding + WPTableViewSectionHeaderViewBottomVerticalPadding;
+    }
+
+    CGFloat titleWidth = [[self class] titleLabelWidthFromSectionWidth:width fixedWidthEnabled:fixedWidthEnabled];
+    return [self sizeForTitle:title andTitleWidth:titleWidth].height + WPTableViewSectionHeaderViewTopVerticalPadding + WPTableViewSectionHeaderViewBottomVerticalPadding;
 }
 
 #pragma mark - Private Methods
 
-+ (CGSize)sizeForTitle:(NSString *)title andWidth:(CGFloat)width
++ (CGSize)sizeForTitle:(NSString *)title andTitleWidth:(CGFloat)titleWidth
 {
-    CGFloat titleWidth = width - 2 * WPTableViewSectionHeaderViewStandardOffset;
     return [title suggestedSizeWithFont:[WPStyleGuide tableviewSectionHeaderFont] width:titleWidth];
+}
+
++ (CGFloat)titleLabelWidthFromSectionWidth:(CGFloat)sectionWidth fixedWidthEnabled:(BOOL)fixedWidthEnabled
+{
+    CGFloat titleLabelWidth = sectionWidth;
+    CGFloat fixedWidth = [[self class] fixedWidth];
+    if (fixedWidthEnabled && fixedWidth > 0) {
+        titleLabelWidth = MIN(fixedWidth, titleLabelWidth);
+    }
+    return titleLabelWidth - (2 * WPTableViewSectionHeaderViewStandardOffset);
+}
+
++ (CGFloat)fixedWidth
+{
+    return IS_IPAD ? WPTableViewFixedWidth : 0.0;
 }
 
 @end

--- a/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m
+++ b/WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m
@@ -37,7 +37,7 @@ CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
 
 - (void)setTitle:(NSString *)title
 {
-    _title = [title uppercaseString];
+    _title = [title uppercaseStringWithLocale:[NSLocale currentLocale]];
     self.titleLabel.text = _title;
     [self setNeedsLayout];
 }
@@ -74,7 +74,10 @@ CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
 
 + (CGSize)sizeForTitle:(NSString *)title andTitleWidth:(CGFloat)titleWidth
 {
-    return [title suggestedSizeWithFont:[WPStyleGuide tableviewSectionHeaderFont] width:titleWidth];
+    // since we use uppercase title by default, it's important to override it here in case
+    // this method is called with a lowercase string which would cause a difference in the height calculation
+    NSString *upppercaseTitle = [title uppercaseStringWithLocale:[NSLocale currentLocale]];
+    return [upppercaseTitle suggestedSizeWithFont:[WPStyleGuide tableviewSectionHeaderFont] width:titleWidth];
 }
 
 + (CGFloat)titleLabelWidthFromSectionWidth:(CGFloat)sectionWidth fixedWidthEnabled:(BOOL)fixedWidthEnabled


### PR DESCRIPTION
There were a few different problems with how we calculated the width and height of the header and footer. I've updated these calculations completely. This is not a perfect solution, although it's a big step up from the previous version. In the future, it would be good to at least remove the duplication of code between footer and header, but as a hotfix this should do for now. With this fix, there should be no overlap between the section header and section content in case the header is multiline.

@aerych & @jleandroperez Can I bother you guys with a quick review?