### PR TITLE
Fixes the title of the device identification VC.

### DIFF
--- a/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/DeviceTableViewController.m
+++ b/WordPress-iOS-Shared-Example/WordPress-iOS-Shared-Example/DeviceTableViewController.m
@@ -17,7 +17,7 @@
 - (id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        self.title = NSLocalizedString(@"Fonts", nil);
+        self.title = NSLocalizedString(@"Device Identification", nil);
         
         [self setupDeviceTests];
     }


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Shared/issues/58).

/cc @SergioEstevao 