### PR TITLE
Add tracks event for NSUserActivity spotlight search

### DIFF
--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -317,6 +317,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatSpotlightSearchOpenedPost,
     WPAnalyticsStatSpotlightSearchOpenedPage,
     WPAnalyticsStatSpotlightSearchOpenedReaderPost,
+    WPAnalyticsStatSpotlightSearchOpenedApp,
     WPAnalyticsStatSkippedConnectingToJetpack,
     WPAnalyticsStatStatsAccessed,
     WPAnalyticsStatStatsInsightsAccessed,


### PR DESCRIPTION
This is a new top-level event we are adding to track when a user opens the app via a spotlight search item that represents a specific user activity. Specific details will be captured in the stat properties.

ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/8782 and https://github.com/wordpress-mobile/WordPress-iOS/issues/8783

@etoledom would you mind taking a quick peek?