### PR TITLE
Add back two missing events so develop will still build

### DIFF
--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -123,6 +123,8 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatMediaLibraryEditedItemMetadata,
     WPAnalyticsStatMediaLibraryPreviewedItem,
     WPAnalyticsStatMediaLibrarySharedItemLink,
+    WPAnalyticsStatMediaLibraryAddedPhoto,
+    WPAnalyticsStatMediaLibraryAddedVideo,
     WPAnalyticsStatMediaLibraryAddedPhotoViaDeviceLibrary,
     WPAnalyticsStatMediaLibraryAddedPhotoViaOtherApps,
     WPAnalyticsStatMediaLibraryAddedPhotoViaStockPhotos,


### PR DESCRIPTION
This adds back `WPAnalyticsStatMediaLibraryAddedPhoto` and `WPAnalyticsStatMediaLibraryAddedVideo` so that other branches of `WordPress-iOS` will still build.