### PR TITLE
Adding support for NSAttributedString in WPNoResultsView message

### DIFF
--- a/WordPressShared/Core/Views/WPNoResultsView.h
+++ b/WordPressShared/Core/Views/WPNoResultsView.h
@@ -11,6 +11,7 @@
 
 @property (nonatomic, strong) NSString                      *titleText;
 @property (nonatomic, strong) NSString                      *messageText;
+@property (nonatomic, strong) NSAttributedString            *attributedMessageText;
 @property (nonatomic, strong) NSString                      *buttonTitle;
 @property (nonatomic, strong) UIView                        *accessoryView;
 @property (nonatomic, strong) UIButton                      *button;

--- a/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/Core/Views/WPNoResultsView.m
@@ -7,8 +7,8 @@
 
 
 @interface WPNoResultsView ()
-@property (nonatomic, strong) UILabel   *titleLabel;
-@property (nonatomic, strong) UILabel   *messageLabel;
+@property (nonatomic, strong) UILabel       *titleLabel;
+@property (nonatomic, strong) UITextView    *messageTextView;
 @end
 
 @implementation WPNoResultsView
@@ -62,7 +62,7 @@
 - (void)commonInit
 {
     [self configureTitleLabel];
-    [self configureMessageLabel];
+    [self configuremessageTextView];
     [self configureButton];
 }
 
@@ -73,15 +73,19 @@
     [self addSubview:_titleLabel];
 }
 
-- (void)configureMessageLabel
+- (void)configuremessageTextView
 {
-    _messageLabel               = [[UILabel alloc] init];
-    _messageLabel.font          = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
-    _messageLabel.textColor     = [WPStyleGuide allTAllShadeGrey];
-    _messageLabel.numberOfLines = 0;
-    _messageLabel.textAlignment = NSTextAlignmentCenter;
-    _messageLabel.adjustsFontForContentSizeCategory = YES;
-    [self addSubview:_messageLabel];
+    _messageTextView                 = [[UITextView alloc] init];
+    _messageTextView.font            = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+    _messageTextView.textColor       = [WPStyleGuide allTAllShadeGrey];
+    _messageTextView.backgroundColor = [UIColor clearColor];
+    _messageTextView.textAlignment   = NSTextAlignmentCenter;
+    _messageTextView.adjustsFontForContentSizeCategory = YES;
+    _messageTextView.editable = NO;
+    _messageTextView.selectable = NO;
+    _messageTextView.textContainerInset = UIEdgeInsetsZero;
+    _messageTextView.textContainer.lineFragmentPadding = 0;
+    [self addSubview:_messageTextView];
 }
 
 - (void)configureButton
@@ -116,25 +120,25 @@
 
     _titleLabel.frame = CGRectMake(0.0f, (CGRectGetMaxY(_accessoryView.frame) > 0 && _accessoryView.hidden != YES ? CGRectGetMaxY(_accessoryView.frame) + 10.0 : 0) , width, titleSize.height);
     
-    CGSize messageSize = [_messageLabel.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
+    CGSize messageSize = [_messageTextView.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
                                                           options:NSStringDrawingUsesLineFragmentOrigin
-                                                       attributes:@{NSFontAttributeName: _messageLabel.font}
+                                                       attributes:@{NSFontAttributeName: _messageTextView.font}
                                                           context:nil].size;
 
-    _messageLabel.frame = CGRectMake(0.0f, CGRectGetMaxY(_titleLabel.frame) + 8.0, width, messageSize.height);
+    _messageTextView.frame = CGRectMake(0.0f, CGRectGetMaxY(_titleLabel.frame) + 8.0, width, messageSize.height);
     
     [_button sizeToFit];
     CGSize buttonSize = _button.frame.size;
     buttonSize.width += 40.0;
-    CGFloat buttonYOrigin = (CGRectGetHeight(_messageLabel.frame) > 0 ? CGRectGetMaxY(_messageLabel.frame) : CGRectGetMaxY(_titleLabel.frame)) + 17.0 ;
+    CGFloat buttonYOrigin = (CGRectGetHeight(_messageTextView.frame) > 0 ? CGRectGetMaxY(_messageTextView.frame) : CGRectGetMaxY(_titleLabel.frame)) + 17.0 ;
     _button.frame = CGRectMake((width - buttonSize.width) / 2, buttonYOrigin, MIN(buttonSize.width, width), buttonSize.height);
     
     
     CGRect bottomViewRect;
     if (_button != nil) {
         bottomViewRect = _button.frame;
-    } else if (_messageLabel.text.length > 0) {
-        bottomViewRect = _messageLabel.frame;
+    } else if (_messageTextView.text.length > 0) {
+        bottomViewRect = _messageTextView.frame;
     } else if (_titleLabel.text.length > 0) {
         bottomViewRect = _titleLabel.frame;
     } else {
@@ -186,6 +190,20 @@
     return [mainImage resizableImageWithCapInsets:capInsets];
 }
 
+- (NSAttributedString *)applyMessageStylesToAttributedString:(NSAttributedString *)attributedString
+{
+    NSRange fullTextRange = NSMakeRange(0, attributedString.string.length);
+    NSMutableAttributedString *mutableAttributedText = [attributedString mutableCopy];
+
+    [mutableAttributedText addAttribute:NSFontAttributeName value:self.messageTextView.font range:fullTextRange];
+    [mutableAttributedText addAttribute:NSForegroundColorAttributeName value:self.messageTextView.textColor range:fullTextRange];
+
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    paragraphStyle.alignment = self.messageTextView.textAlignment;
+    [mutableAttributedText addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:fullTextRange];
+
+    return mutableAttributedText;
+}
 
 #pragma mark - Properties
 
@@ -201,12 +219,24 @@
 }
 
 - (NSString *)messageText {
-    return _messageLabel.text;
+    return _messageTextView.text;
 }
 
 - (void)setMessageText:(NSString *)message {
-    _messageLabel.text = message;
+    _messageTextView.text = message;
     [self setNeedsLayout];
+}
+
+- (NSAttributedString *)attributedMessageText
+{
+    return self.messageTextView.attributedText;
+}
+
+- (void)setAttributedMessageText:(NSAttributedString *)attributedMessageText
+{
+    NSAttributedString * finalAttributedText = [self applyMessageStylesToAttributedString:attributedMessageText];
+    self.messageTextView.attributedText = finalAttributedText;
+    self.messageTextView.selectable = YES;
 }
 
 - (void)setAccessoryView:(UIView *)accessoryView {


### PR DESCRIPTION
This PR adds support for attributes in the WPNoResultsView's message 'label'.
This is used to show a tappable link in the Stock Photos feature in the Main WPiOS app.

These changes where already reviewed and accepted [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/9136), but since we were working in a feature branch, this changes didn't make it to develop on time.

This is a re-implementation of those changes so they are accessible in the feature branch after updating with develop in the main WPiOS project.