### PR TITLE
WPAnalytics: add clearQueuedEvents method

### DIFF
--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -397,6 +397,7 @@ extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo;
 + (void)track:(WPAnalyticsStat)stat;
 + (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties;
 + (void)endSession;
++ (void)clearQueuedEvents;
 
 @end
 
@@ -411,5 +412,6 @@ extern NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo;
 - (void)refreshMetadata;
 - (void)beginTimerForStat:(WPAnalyticsStat)stat;
 - (void)endTimerForStat:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties;
+- (void)clearQueuedEvents;
 
 @end

--- a/WordPressShared/Core/Analytics/WPAnalytics.m
+++ b/WordPressShared/Core/Analytics/WPAnalytics.m
@@ -90,4 +90,13 @@ NSString *const WPAnalyticsStatEditorPublishedPostPropertyVideo = @"with_videos"
     }
 }
 
++ (void)clearQueuedEvents
+{
+    for (id<WPAnalyticsTracker>tracker in [self trackers]) {
+        if ([tracker respondsToSelector:@selector(clearQueuedEvents)]) {
+            [tracker clearQueuedEvents];
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
This adds an optional `clearQueuedEvents` method to the `WPAnalyticsTracker` protocol.

I'm gonna use it to fix/cleanly implement https://github.com/wordpress-mobile/WordPress-iOS/issues/9343.