### PR TITLE
Get rid of Safe-Expectations.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,8 +9,7 @@ target 'WordPressShared' do
   project 'WordPressShared.xcodeproj'
 
   pod 'CocoaLumberjack', '~> 3.4'
-  pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
-  pod 'NSObject-SafeExpectations', '0.0.2'
+  pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'  
 
   target 'WordPressSharedTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - NSObject-SafeExpectations (0.0.2)
   - OCMock (3.4.1)
   - OHHTTPStubs (6.1.0):
     - OHHTTPStubs/Default (= 6.1.0)
@@ -32,21 +31,28 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.4)
   - Expecta (= 1.0.6)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - NSObject-SafeExpectations (= 0.0.2)
   - OCMock (~> 3.4)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CocoaLumberjack
+    - Expecta
+    - FormatterKit
+    - OCMock
+    - OHHTTPStubs
+    - Specta
+
 SPEC CHECKSUMS:
   CocoaLumberjack: 2e258a064cacc8eb9a2aca318e24d02a0a7fd56d
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
-PODFILE CHECKSUM: fb04b51263031cd65a961f5ee979454a7e1ab41e
+PODFILE CHECKSUM: eb829a687e5e6f6e8da92abc9dbeb35b90e32550
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2

--- a/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared.xcodeproj/project.pbxproj
@@ -460,7 +460,6 @@
 				829DD13A1EC9EED200AB8C12 /* Frameworks */,
 				829DD13B1EC9EED200AB8C12 /* Headers */,
 				829DD13C1EC9EED200AB8C12 /* Resources */,
-				E3FF3E6A15093B9CFF57DB95 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -480,7 +479,6 @@
 				829DD1441EC9EED200AB8C12 /* Frameworks */,
 				829DD1451EC9EED200AB8C12 /* Resources */,
 				F47EB302F575BA168C0E7DB8 /* [CP] Embed Pods Frameworks */,
-				09EE7ACDD61CC21C126750FF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -555,21 +553,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09EE7ACDD61CC21C126750FF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WordPressSharedTests/Pods-WordPressSharedTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8C446B5942DC8541369A811F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -606,21 +589,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E3FF3E6A15093B9CFF57DB95 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WordPressShared/Pods-WordPressShared-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F47EB302F575BA168C0E7DB8 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -634,7 +602,6 @@
 				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
-				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -644,7 +611,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/WordPressShared/Core/Utility/Languages.swift
+++ b/WordPressShared/Core/Utility/Languages.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NSObject_SafeExpectations
 
 /// This helper class allows us to map WordPress.com LanguageID's into human readable language strings.
 ///
@@ -30,8 +29,8 @@ public class WordPressComLanguageDatabase: NSObject {
         let parsed = try! JSONSerialization.jsonObject(with: raw, options: [.mutableContainers, .mutableLeaves]) as? NSDictionary
 
         // Parse All + Popular: All doesn't contain Popular. Otherwise the json would have dupe data. Right?
-        let parsedAll = Language.fromArray(parsed!.array(forKey: Keys.all) as! [NSDictionary])
-        let parsedPopular = Language.fromArray(parsed!.array(forKey: Keys.popular) as! [NSDictionary])
+        let parsedAll = Language.fromArray(parsed![Keys.all] as! [[String: Any]])
+        let parsedPopular = Language.fromArray(parsed![Keys.popular] as! [[String: Any]])
         let merged = parsedAll + parsedPopular
 
         // Done!
@@ -136,10 +135,10 @@ public class WordPressComLanguageDatabase: NSObject {
 
         /// Designated initializer. Will fail if any of the required properties is missing
         ///
-        init?(dict: NSDictionary) {
-            guard let unwrappedId = dict.number(forKey: Keys.identifier)?.intValue,
-                        let unwrappedSlug = dict.string(forKey: Keys.slug),
-                        let unwrappedName = dict.string(forKey: Keys.name) else {
+        init?(dict: [String: Any]) {
+            guard let unwrappedId = (dict[Keys.identifier] as? NSNumber)?.intValue,
+                        let unwrappedSlug = dict[Keys.slug] as? String,
+                        let unwrappedName = dict[Keys.name] as? String else {
                 id = Int.min
                 name = String()
                 slug = String()
@@ -154,7 +153,7 @@ public class WordPressComLanguageDatabase: NSObject {
 
         /// Given an array of raw languages, will return a parsed array.
         ///
-        public static func fromArray(_ array: [NSDictionary]) -> [Language] {
+        public static func fromArray(_ array: [[String:Any]] ) -> [Language] {
             return array.compactMap {
                 return Language(dict: $0)
             }


### PR DESCRIPTION
This PR removes the dependency of Safe Expectation from WordPress-iOS-Shared.

Make sure all the tests are running.