### PR TITLE
WPNoResultsView: Turn off clip to bounds in message textview.

### DIFF
--- a/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/Core/Views/WPNoResultsView.m
@@ -83,6 +83,7 @@
     _messageTextView.adjustsFontForContentSizeCategory = YES;
     _messageTextView.editable = NO;
     _messageTextView.selectable = NO;
+    _messageTextView.clipsToBounds = NO;
     _messageTextView.textContainerInset = UIEdgeInsetsZero;
     _messageTextView.textContainer.lineFragmentPadding = 0;
     [self addSubview:_messageTextView];


### PR DESCRIPTION
I'm working on a tweak in WPiOS where an icon is displayed in the message text of a no results view:

<img width="269" alt="screen shot 2018-05-23 at 11 37 56" src="https://user-images.githubusercontent.com/4780/40419621-c945aa76-5e7d-11e8-9a07-db67b6e6efff.png">

If `clipsToBounds` is `YES` on the message text view, the top and bottom of the icon will be clipped because they fall outside the bounds of the textView. I've disabled clipping in this PR, which I don't think should have any negative effects.

**To test:**

* Check out this PR for WPiOS, which points to this branch of WordPressShared: https://github.com/wordpress-mobile/WordPress-iOS/pull/9412
* Build and run
* Check that the icon in the no results view of Reader > Saved Posts isn't clipped
* Check that other no results views in WPiOS that have message text still look okay