### PR TITLE
Add accessibility label override to no results view

### DIFF
--- a/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/Core/Views/WPNoResultsView.m
@@ -208,6 +208,14 @@
 
 #pragma mark - Properties
 
+- (void)setAccessibilityLabel:(NSString *)accessibilityLabel {
+    [super setAccessibilityLabel:accessibilityLabel];
+
+    // If an accessibility label is set, use it to override the displayed
+    // title and message.
+    self.isAccessibilityElement = (accessibilityLabel) ? YES : NO;
+}
+
 - (NSString *)titleText {
     return _titleLabel.text;
 }


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-iOS/pull/9412, we added a no results view for Reader Saved Posts, which includes an icon in the message text:

<img width="254" alt="screen shot 2018-05-23 at 16 34 01" src="https://user-images.githubusercontent.com/4780/40538420-90979198-6009-11e8-87d0-f7f0aaaf1fda.png">

For users using Voiceover, this won't make complete sense when read out as-is. This PR allows us to use the no results view's `accessibilityLabel` property to provide alternative text for the no results view for Voiceover users. When an accessibility label is set, we treat the entire no results view as a single accessibility element.

**To test:**

* Check out the WPiOS branch `issue/9463-saved-posts-accessibility`.
* Navigate to Saved Posts in Reader, and ensure you have no items in there.
* Enable Voiceover, and either swipe left-to-right until the selection reaches the no results view, or otherwise tap the no results view.
* When it's read out, ensure the new accessibility label is read, rather than the individual labels.