### PR TITLE
Issues/filter gutenberg comments

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.0.4"
+  s.version       = "1.0.5"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -11,6 +11,7 @@ import Foundation
         static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?</style>", options: .caseInsensitive)
         static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?</script>", options: .caseInsensitive)
         static let tableTags = try! NSRegularExpression(pattern: "<table[^>]*?>[\\s\\S]*?</table>", options: .caseInsensitive)
+        static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:\\S+? --></p>", options: .caseInsensitive)
 
         // Normalizaing Paragraphs
         static let divTagsStart = try! NSRegularExpression(pattern: "<div[^>]*>", options: .caseInsensitive)
@@ -80,6 +81,11 @@ import Foundation
                                                                     withTemplate: "")
 
         content = RegEx.tableTags.stringByReplacingMatches(in: content,
+                                                                   options: .reportCompletion,
+                                                                   range: NSRange(location: 0, length: content.count),
+                                                                   withTemplate: "")
+
+        content = RegEx.gutenbergComments.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
                                                                    range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: "")

--- a/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -11,7 +11,7 @@ import Foundation
         static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?</style>", options: .caseInsensitive)
         static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?</script>", options: .caseInsensitive)
         static let tableTags = try! NSRegularExpression(pattern: "<table[^>]*?>[\\s\\S]*?</table>", options: .caseInsensitive)
-        static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:.+? --></p>[\\n]?", options: .caseInsensitive)
+        static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:.+? /?--></p>[\\n]?", options: .caseInsensitive)
 
         // Normalizaing Paragraphs
         static let divTagsStart = try! NSRegularExpression(pattern: "<div[^>]*>", options: .caseInsensitive)

--- a/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -11,7 +11,7 @@ import Foundation
         static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?</style>", options: .caseInsensitive)
         static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?</script>", options: .caseInsensitive)
         static let tableTags = try! NSRegularExpression(pattern: "<table[^>]*?>[\\s\\S]*?</table>", options: .caseInsensitive)
-        static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:\\S+? --></p>", options: .caseInsensitive)
+        static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:.+? --></p>[\\n]?", options: .caseInsensitive)
 
         // Normalizaing Paragraphs
         static let divTagsStart = try! NSRegularExpression(pattern: "<div[^>]*>", options: .caseInsensitive)

--- a/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/WordPressSharedTests/RichContentFormatterTests.swift
@@ -13,7 +13,7 @@ class RichContentFormatterTests: XCTestCase {
 
     func testRemoveForbiddenTags() {
         let str = "<p>test</p><p>test</p><img>"
-        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><script>alert();</script><style>body{color:#000;}</style>"
+        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><p><!-- wp:self-closing-tag /--></p><script>alert();</script><style>body{color:#000;}</style>"
         let sanitizedStr = RichContentFormatter.removeForbiddenTags(styleStr)
         XCTAssertTrue(str == sanitizedStr, "The forbidden tags were not removed.")
     }

--- a/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/WordPressSharedTests/RichContentFormatterTests.swift
@@ -12,8 +12,8 @@ class RichContentFormatterTests: XCTestCase {
 
 
     func testRemoveForbiddenTags() {
-        let str = "<p>test</p><p>test</p>"
-        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style>"
+        let str = "<p>test</p><p>test</p><img>"
+        let styleStr = "<script>alert();</script><style>body{color:#000;}</style><p>test</p><script>alert();</script><style>body{color:#000;}</style><p>test</p><p><!-- wp:paragraph {\"fontSize\":\"large\"}--></p><p><!-- /wp:paragraph --></p>\n<img><script>alert();</script><style>body{color:#000;}</style>"
         let sanitizedStr = RichContentFormatter.removeForbiddenTags(styleStr)
         XCTAssertTrue(str == sanitizedStr, "The forbidden tags were not removed.")
     }


### PR DESCRIPTION
Refs: https://github.com/wordpress-mobile/WordPress-iOS/issues/9470

This PR updates the `RichContentFormatter` to remove Gutenberg comments and their surrounding paragraph tags from the passed content.

The test is updated to account for the change.

The pod version is bumped.

To test: 

Run the unit tests and confirm they pass.   

Bonus points for pointing the WordPress app's Podfile to the last commit in this branch and confirming in the Reader that Gutenberg posts have paragraphs that are properly spaced.

Needs Review: @frosty could I trouble you for a review of this one? 