### PR TITLE
Fix pod lint warnings

### DIFF
--- a/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -146,7 +146,7 @@ extension WPStyleGuide {
     /// This font will never change its size.
     ///
     /// - Parameters:
-    ///   - for: The base UIFontTextStyle to take the size from.
+    ///   - style: The base UIFontTextStyle to take the size from.
     ///   - weight: The desired font weight
     /// - Returns: The created font.
     ///


### PR DESCRIPTION
This PR fixes a warning that was being thrown when attempting to push a new pod release:

```
 -> WordPressShared (1.0.9)
    - WARN  | xcodebuild:  /Users/frosty/Library/Developer/Xcode/DerivedData/App-hcdcoxdssrhlaoeunehkzekojbln/Build/Products/Release-iphonesimulator/WordPressShared/WordPressShared.framework/Headers/WordPressShared-Swift.h:446:12: warning: parameter 'for' not found in the function declaration [-Wdocumentation]
    - NOTE  | xcodebuild:  /Users/frosty/Library/Developer/Xcode/DerivedData/App-hcdcoxdssrhlaoeunehkzekojbln/Build/Products/Release-iphonesimulator/WordPressShared/WordPressShared.framework/Headers/WordPressShared-Swift.h:446:12: note: did you mean 'style'?

[!] WordPressShared did not pass validation, due to 1 warning (but you can use `--allow-warnings` to ignore it).
```

The fix was simply to update the parameter name in a comment – we were using the external rather than internal parameter name.

**To Test**

* Run `pod lib lint` in the root of this project. You should see the message `WordPressShared passed validation`. You may need to clean your DerivedData if you've recently built the project with CocoaPods.