### PR TITLE
Added Site Creation events to Tracks

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.1.1-beta.2"
+  s.version       = "1.1.1-beta.3"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatNoStat, // Since we can't have a nil enum we'll use this to act as the nil
@@ -39,10 +39,16 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatCreateAccountEmailExists,
     WPAnalyticsStatCreateAccountUsernameExists,
     WPAnalyticsStatCreateAccountFailed,
-    WPAnalyticsStatCreateSiteValidationFailed,
+    WPAnalyticsStatCreateSiteProcessBegun,
+    WPAnalyticsStatCreateSiteCategoryViewed,
+    WPAnalyticsStatCreateSiteDetailsViewed,
+    WPAnalyticsStatCreateSiteDomainViewed,
+    WPAnalyticsStatCreateSiteThemeViewed,
+    WPAnalyticsStatCreateSiteRequestInitiated,
     WPAnalyticsStatCreateSiteCreationFailed,
     WPAnalyticsStatCreateSiteSetTaglineFailed,
     WPAnalyticsStatCreateSiteSetThemeFailed,
+    WPAnalyticsStatCreateSiteValidationFailed,
     WPAnalyticsStatDefaultAccountChanged,
     WPAnalyticsStatDeepLinked,
     WPAnalyticsStatDeepLinkFailed,


### PR DESCRIPTION
Defined additional Site Creation events, as referenced in [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/10208) in `WordPress-iOS`.