### PR TITLE
Added event to track site creation success viewed

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.1.1-beta.3"
+  s.version       = "1.1.1-beta.4"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatCreateSiteDomainViewed,
     WPAnalyticsStatCreateSiteThemeViewed,
     WPAnalyticsStatCreateSiteRequestInitiated,
+    WPAnalyticsStatCreateSiteSuccessViewed,
     WPAnalyticsStatCreateSiteCreationFailed,
     WPAnalyticsStatCreateSiteSetTaglineFailed,
     WPAnalyticsStatCreateSiteSetThemeFailed,


### PR DESCRIPTION
In reference to [PR feedback](https://github.com/wordpress-mobile/WordPress-iOS/pull/10210/) in `WordPress-iOS`, this PR defines an additional site creation event : _Site Viewed_.