### PR TITLE
Added new event to properly track notification actions

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.1.1"
+  s.version       = "1.2.0-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -267,6 +267,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatPushAuthenticationIgnored,
     WPAnalyticsStatPushNotificationAlertPressed,
     WPAnalyticsStatPushNotificationReceived,
+    WPAnalyticsStatPushNotificationQuickActionCompleted,
     WPAnalyticsStatPushNotificationPrimerSeen,
     WPAnalyticsStatPushNotificationPrimerAllowTapped,
     WPAnalyticsStatPushNotificationPrimerNoTapped,


### PR DESCRIPTION
Further addresses [#6256](https://github.com/wordpress-mobile/WordPress-iOS/issues/6256), by adding a new event `WPAnalyticsStatPushNotificationQuickActionCompleted`