### PR TITLE
Rich Content: Do not filter table tags from rich content.

### DIFF
--- a/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -10,7 +10,6 @@ import Foundation
         // Forbidden tags
         static let styleTags = try! NSRegularExpression(pattern: "<style[^>]*?>[\\s\\S]*?</style>", options: .caseInsensitive)
         static let scriptTags = try! NSRegularExpression(pattern: "<script[^>]*?>[\\s\\S]*?</script>", options: .caseInsensitive)
-        static let tableTags = try! NSRegularExpression(pattern: "<table[^>]*?>[\\s\\S]*?</table>", options: .caseInsensitive)
         static let gutenbergComments = try! NSRegularExpression(pattern: "<p><!-- /?wp:.+? /?--></p>[\\n]?", options: .caseInsensitive)
 
         // Normalizaing Paragraphs
@@ -79,11 +78,6 @@ import Foundation
                                                                     options: .reportCompletion,
                                                                     range: NSRange(location: 0, length: content.count),
                                                                     withTemplate: "")
-
-        content = RegEx.tableTags.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: "")
 
         content = RegEx.gutenbergComments.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,


### PR DESCRIPTION
For context see https://github.com/wordpress-mobile/WordPress-iOS/issues/10333

Support for tables in NSAttributedStrings isn't perfect but seems good enough at this point to no longer treat tables as forbidden tags.  This PR removes the regex that would filter table tags from the passed content string.

To Test:
Run the tests, particularly `RichContentFormatterTests` and confirm tests pass.  

I'm not bumping the podspec version in this PR (yet) in case there are other changes we want to include in the next version. 

@nheagy game for a quick review? 
