### PR TITLE
Use the repo URL instead of the marketing URL

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                     This is the first step required to build WordPress-iOS with UI components.
                     DESC
 
-  s.homepage      = "http://apps.wordpress.com"
+  s.homepage      = "https://github.com/wordpress-mobile/WordPress-iOS-Shared"
   s.license       = "GPLv2"
   s.author        = { "WordPress" => "mobile@automattic.com" }
   s.platform      = :ios, "10.0"


### PR DESCRIPTION
This fixes #167

Pointing folks to GitHub instead of apps.wordpress.com to me makes sense in the context of a `Podspec` anyways.