### PR TITLE
Exposed new event to track sharing a site via Reader

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.6.1-beta.1"  
+  s.version       = "1.7.0-beta.1"  
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -341,6 +341,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatReaderSiteFollowed,
     WPAnalyticsStatReaderSitePreviewed,
     WPAnalyticsStatReaderSiteUnfollowed,
+    WPAnalyticsStatReaderSiteShared,
     WPAnalyticsStatReaderTagFollowed,
     WPAnalyticsStatReaderTagLoaded,
     WPAnalyticsStatReaderTagPreviewed,


### PR DESCRIPTION
Exposes a new event associated with the tracking of Blog sharing via [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/10898).