### PR TITLE
Issues/format video tags

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.7.0-beta.2"  
+  s.version       = "1.7.0-beta.3"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -19,6 +19,7 @@ import Foundation
         static let pTagsEnd = try! NSRegularExpression(pattern: "</p>\\s*</p>", options: .caseInsensitive)
         static let newLines = try! NSRegularExpression(pattern: "\\n", options: .caseInsensitive)
         static let preTags = try! NSRegularExpression(pattern: "<pre[^>]*>[\\s\\S]*?</pre>", options: .caseInsensitive)
+        static let videoTags = try! NSRegularExpression(pattern: "<video[^>]*>", options: .caseInsensitive)
 
         // Inline Styles
         static let styleAttr = try! NSRegularExpression(pattern: "\\s*style=\"[^\"]*\"", options: .caseInsensitive)
@@ -56,7 +57,7 @@ import Foundation
         content = (content as NSString).replacingHTMLEmoticonsWithEmoji() as String
         content = formatGutenbergGallery(content)
         content = resizeGalleryImageURL(content, isPrivateSite: isPrivate)
-
+        content = formatVideoTags(content)
         return content
     }
 
@@ -333,6 +334,32 @@ import Foundation
             }
             let image = mString.substring(with: match.range(at: 1))
             mString.replaceCharacters(in: match.range, with: image)
+        }
+
+        return mString as String
+    }
+
+    /// Format video tags to ensure they have the desired markup.
+    ///
+    /// - Parameters:
+    ///     - string: The content string to format.
+    ///
+    /// - Returns: The formatted string.
+    ///
+    @objc public class func formatVideoTags(_ string: String) -> String {
+        let mString = NSMutableString(string: string)
+
+        // Find video tags.
+        let matches = RegEx.videoTags.matches(in: mString as String, options: [], range: NSRange(location: 0, length: mString.length))
+
+        // For each video tag, check for controls attribute
+        for match in matches.reversed() {
+            let tag = mString.substring(with: match.range) as NSString
+            if !tag.contains("controls") {
+                // Add the controls attribute.
+                let range = NSRange(location: match.range.location, length: 6)
+                mString.replaceCharacters(in: range, with: "<video controls")
+            }
         }
 
         return mString as String

--- a/WordPressSharedTests/RichContentFormatterTests.swift
+++ b/WordPressSharedTests/RichContentFormatterTests.swift
@@ -60,4 +60,18 @@ class RichContentFormatterTests: XCTestCase {
         range = sanitizedString.range(of: "figcaption")
         XCTAssertTrue(range.location != NSNotFound)
     }
+
+    func testFormatVideoTags() {
+        let str1 = "<p>Some text.</p><video></video><p>Some text.</p>"
+        let sanitizedStr1 = RichContentFormatter.formatVideoTags(str1) as NSString
+        XCTAssert(sanitizedStr1.contains("controls"))
+
+        let str2 = "<p>Some text.</p><video autoplay></video><p>Some text.</p>"
+        let sanitizedStr2 = RichContentFormatter.formatVideoTags(str2) as NSString
+        XCTAssert(sanitizedStr2.contains(" controls "))
+
+        let str3 = "<p>Some text.</p><video controls></video><p>Some text.</p>"
+        let sanitizedStr3 = RichContentFormatter.formatVideoTags(str3) as NSString
+        XCTAssert(!sanitizedStr3.contains("controls controls"))
+    }
 }


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/10930

This PR adds some new parsing logic to ensure that video tags have the `controls` parameter specified. 

To test: 
Run the new tests and ensure they pass. 
Bonus: Test the WPiOS reader against this update and confirm the video example in the referenced issue plays.

@bummytime could I trouble you for a review?