### PR TITLE
Add Grey 700 color

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.7.1-beta.3"
+  s.version       = "1.7.1-beta.4"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Views/WPStyleGuide.h
+++ b/WordPressShared/Core/Views/WPStyleGuide.h
@@ -38,6 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *)greyDarken20;
 + (UIColor *)greyDarken30;
 + (UIColor *)darkGrey;
+
+/**
+ * Grey color with hex value #3d4145
+ */
++ (UIColor *)grey700;
 + (UIColor *)jazzyOrange;
 + (UIColor *)fireOrange;
 + (UIColor *)validGreen;

--- a/WordPressShared/Core/Views/WPStyleGuide.m
+++ b/WordPressShared/Core/Views/WPStyleGuide.m
@@ -185,6 +185,10 @@
     return [self colorWithR:46 G:68 B:83 alpha:1.0];
 }
 
++ (UIColor *)grey700
+{
+    return [self colorWithR:61 G:65 B:69 alpha:1.0];
+}
 
 #pragma mark - Oranges
 


### PR DESCRIPTION
The color (`#3d4145`) will be used to implement wordpress-mobile/WordPress-iOS#11033. 

This is a companion pull request of wordpress-mobile/WordPress-iOS#11118.