### PR TITLE
Added analytics event for stats refresh chart interactions

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.7.3-beta.1"
+  s.version       = "1.7.3-beta.2"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -456,6 +456,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatSkippedConnectingToJetpack,
     WPAnalyticsStatStatsAccessed,
     WPAnalyticsStatStatsInsightsAccessed,
+    WPAnalyticsStatStatsOverviewBarChartTapped,
     WPAnalyticsStatStatsPeriodDaysAccessed,
     WPAnalyticsStatStatsPeriodWeeksAccessed,
     WPAnalyticsStatStatsPeriodMonthsAccessed,


### PR DESCRIPTION
Fixes [#11066](https://github.com/wordpress-mobile/WordPress-iOS/issues/11066), by exposing a new analytics event for stats chart interaction.

It may be helpful to review the [corresponding WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/11372).