### PR TITLE
Podspec version fixed

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.7.3-beta.3"
+  s.version       = "1.7.4-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC


### PR DESCRIPTION
This PR fixes the podspec version introduced by [this](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/197) PR.
Since **1.7.3** has been delivered, the correct version should be **1.7.4-beta.1**.