### PR TITLE
Removes a stat that's no longer used.

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.1-beta.1"
+  s.version       = "1.8.1-beta.2"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -134,6 +134,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEnhancedSiteCreationSuccessLoading,
     WPAnalyticsStatEnhancedSiteCreationSuccessPreviewViewed,
     WPAnalyticsStatEnhancedSiteCreationSuccessPreviewLoaded,
+    WPAnalyticsStatEnhancedSiteCreationSuccessPreviewOkButtonTapped,
     WPAnalyticsStatEnhancedSiteCreationErrorShown,
     WPAnalyticsStatGiphyAccessed,
     WPAnalyticsStatGiphySearched,

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -134,7 +134,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEnhancedSiteCreationSuccessLoading,
     WPAnalyticsStatEnhancedSiteCreationSuccessPreviewViewed,
     WPAnalyticsStatEnhancedSiteCreationSuccessPreviewLoaded,
-    WPAnalyticsStatEnhancedSiteCreationCompleted,
     WPAnalyticsStatEnhancedSiteCreationErrorShown,
     WPAnalyticsStatGiphyAccessed,
     WPAnalyticsStatGiphySearched,


### PR DESCRIPTION
Reference: https://github.com/wordpress-mobile/WordPress-iOS/issues/11809

Changes:
- Stat `wpios_enhanced_site_creation_completed` will no longer be bumped.
- We're going back to bumping stat `wpios_site_created`.

### Testing:

1. Check out WPiOS branch `issue/11809-roll-back-to-bumping-site-created` (which was updated to point to the last commit in this branch).
2. Install the pods.
3. Make sure the App builds correctly.