### PR TITLE
Add post list toggle button event

### DIFF
--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -314,6 +314,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatPostListStatusFilterChanged,
     WPAnalyticsStatPostListTrashAction,
     WPAnalyticsStatPostListViewAction,
+    WPAnalyticsStatPostListToggleButtonPressed,
     WPAnalyticsStatPostRevisionsListViewed,
     WPAnalyticsStatPostRevisionsDetailViewed,
     WPAnalyticsStatPostRevisionsDetailCancelled,


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/11830

Adds:

* Post list event for when the toggle button is pressed to toggle the visualization mode