### PR TITLE
Remove table view styling methods

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.3"
+  s.version       = "1.8.4-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Views/WPStyleGuide.h
+++ b/WordPressShared/Core/Views/WPStyleGuide.h
@@ -50,7 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
 // Misc
 + (UIColor *)keyboardColor;
 + (UIColor *)textFieldPlaceholderGrey;
-+ (UIColor *)tableViewActionColor;
 
 // Bar Button Styles
 + (UIBarButtonItemStyle)barButtonStyleForDone;
@@ -59,17 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setRightBarButtonItemWithCorrectSpacing:(UIBarButtonItem *)barButtonItem forNavigationItem:(UINavigationItem *)navigationItem;
 + (void)configureNavigationBarAppearance;
 + (void)configureDocumentPickerNavBarAppearance;
-
-// View and TableView Helpers
-+ (void)configureColorsForView:(nullable UIView *)view andTableView:(nullable UITableView *)tableView;
-+ (void)configureColorsForView:(nullable UIView *)view collectionView:(nullable UICollectionView *)collectionView;
-+ (void)configureTableViewCell:(nullable UITableViewCell *)cell;
-+ (void)configureTableViewSmallSubtitleCell:(nullable UITableViewCell *)cell;
-+ (void)configureTableViewActionCell:(nullable UITableViewCell *)cell;
-+ (void)configureTableViewDestructiveActionCell:(nullable UITableViewCell *)cell;
-+ (void)configureTableViewTextCell:(nullable WPTextFieldTableViewCell *)cell;
-+ (void)configureTableViewSectionHeader:(nullable UIView *)header;
-+ (void)configureTableViewSectionFooter:(nullable UIView *)footer;
 
 // Move to a feature category
 + (UIColor *)buttonActionColor;

--- a/WordPressShared/Core/Views/WPStyleGuide.m
+++ b/WordPressShared/Core/Views/WPStyleGuide.m
@@ -262,11 +262,6 @@
     return [self grey];
 }
 
-+ (UIColor *)tableViewActionColor
-{
-    return [self wordPressBlue];
-}
-
 // TODO: Move to feature category
 + (UIColor *)buttonActionColor
 {
@@ -332,93 +327,6 @@
     [[UINavigationBar appearance] setTintColor:[WPStyleGuide mediumBlue]];
     [[UIBarButtonItem appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName: [WPStyleGuide mediumBlue]} forState:UIControlStateNormal];
 }
-
-#pragma mark - View and TableView Styles
-
-+ (void)configureColorsForView:(UIView *)view andTableView:(UITableView *)tableView
-{
-    tableView.backgroundView = nil;
-    view.backgroundColor = [WPStyleGuide greyLighten30];
-    tableView.backgroundColor = [WPStyleGuide greyLighten30];
-    tableView.separatorColor = [WPStyleGuide greyLighten20];
-}
-
-+ (void)configureColorsForView:(UIView *)view collectionView:(UICollectionView *)collectionView
-{
-    collectionView.backgroundView = nil;
-    collectionView.backgroundColor = [WPStyleGuide greyLighten30];
-    view.backgroundColor = [WPStyleGuide greyLighten30];
-}
-
-+ (void)configureTableViewCell:(UITableViewCell *)cell
-{
-    cell.textLabel.font = [self tableviewTextFont];
-    [cell.textLabel sizeToFit];
-
-    cell.detailTextLabel.font = [self tableviewSubtitleFont];
-    [cell.detailTextLabel sizeToFit];
-    
-    cell.textLabel.textColor = [self darkGrey];
-    cell.detailTextLabel.textColor = [self grey];
-    
-    cell.imageView.tintColor = [self greyLighten10];
-}
-
-+ (void)configureTableViewSmallSubtitleCell:(UITableViewCell *)cell
-{
-    [self configureTableViewCell:cell];
-    cell.detailTextLabel.font = [self subtitleFont];
-    cell.detailTextLabel.textColor = [self darkGrey];
-}
-
-+ (void)configureTableViewActionCell:(UITableViewCell *)cell
-{
-    [self configureTableViewCell:cell];
-    cell.textLabel.font = [self tableviewTextFont];
-    cell.textLabel.textColor = [self tableViewActionColor];
-}
-
-+ (void)configureTableViewDestructiveActionCell:(UITableViewCell *)cell
-{
-    [self configureTableViewActionCell:cell];
-    cell.textLabel.textAlignment = NSTextAlignmentCenter;
-    cell.textLabel.textColor = [self errorRed];
-}
-
-+ (void)configureTableViewTextCell:(WPTextFieldTableViewCell *)cell
-{
-    [self configureTableViewCell:cell];
-    cell.textField.font = [self tableviewSubtitleFont];
-    
-    if (cell.textField.enabled) {
-        cell.textField.textColor = [self darkBlue];
-        cell.textField.textAlignment = NSTextAlignmentLeft;
-    } else {
-        cell.textField.textColor = [self grey];
-        cell.textField.textAlignment = NSTextAlignmentRight;
-    }
-}
-
-+ (void)configureTableViewSectionHeader:(UITableViewHeaderFooterView *)header
-{
-	if (![header isKindOfClass:[UITableViewHeaderFooterView class]]) {
-		return;
-	}
-	header.textLabel.textColor = [self whisperGrey];
-}
-
-+ (void)configureTableViewSectionFooter:(UITableViewHeaderFooterView *)footer
-{
-	if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
-		return;
-	}
-    if (footer.textLabel.userInteractionEnabled) {
-        footer.textLabel.textColor = [self wordPressBlue];
-    } else {
-        footer.textLabel.textColor = [self greyDarken10];
-    }
-}
-
 
 #pragma mark - Deprecated Colors
 


### PR DESCRIPTION
This PR removes the table view styling methods. These will now belong to the apps themselves. I believe that only WPiOS was using these because of the app-specific colors. This will make their use more clear.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/11967