### PR TITLE
Add analytics events for app icon changes

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.4-beta.2"
+  s.version       = "1.8.4-beta.3"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -8,6 +8,8 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatActivityLogViewed,
     WPAnalyticsStatActivityLogDetailViewed,
     WPAnalyticsStatActivityLogRewindStarted,
+    WPAnalyticsStatAppIconChanged,
+    WPAnalyticsStatAppIconReset,
     WPAnalyticsStatAppInstalled,
     WPAnalyticsStatAppReviewsCanceledFeedbackScreen,
     WPAnalyticsStatAppReviewsDeclinedToRateApp,


### PR DESCRIPTION
This PR simply adds a couple of analytics events for the new app icon switching feature in WPiOS.

```
WPAnalyticsStatAppIconChanged
WPAnalyticsStatAppIconReset
```