### PR TITLE
Bump version number to 1.8.5-beta.1

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.4"
+  s.version       = "1.8.5-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC


### PR DESCRIPTION
This is necessary because I merged #207 without bumping the version, on account of the source branch being from a third party (@leandroalonso).