### PR TITLE
CircleCI: Publish pod when the repo is tagged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.25
+  ios: wordpress-mobile/ios@0.0.35
 
 workflows:
   test_and_validate:
@@ -18,3 +18,13 @@ workflows:
           name: Validate Podspec
           xcode-version: "10.2.0"
           podspec-path: WordPressShared.podspec
+      - ios/publish-podspec:
+          name: Publish to Trunk
+          xcode-version: "10.2.0"
+          podspec-path: WordPressShared.podspec
+          post-to-slack: true
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
### Description

Adding a CircleCI job that will run `pod trunk push` on the podspec whenever the repo is tagged. This is already in use and tested on WordPressAuthenticator.

### Testing Details

We can't really test this directly on the PR, but you can see it was tested here: https://github.com/wordpress-mobile/circleci-orbs/pull/38