### PR TITLE
Fix memory layout issues with DDLogLevel

### DIFF
--- a/WordPressShared/Core/Logging/WPSharedLogging.h
+++ b/WordPressShared/Core/Logging/WPSharedLogging.h
@@ -1,2 +1,4 @@
-int WPSharedGetLoggingLevel(void);
-void WPSharedSetLoggingLevel(int level);
+@import CocoaLumberjack;
+
+DDLogLevel WPSharedGetLoggingLevel(void);
+void WPSharedSetLoggingLevel(DDLogLevel level);

--- a/WordPressShared/Core/Logging/WPSharedLogging.m
+++ b/WordPressShared/Core/Logging/WPSharedLogging.m
@@ -1,10 +1,10 @@
 #import "WPSharedLogging.h"
 #import "WPSharedLoggingPrivate.h"
 
-int WPSharedGetLoggingLevel() {
+DDLogLevel WPSharedGetLoggingLevel() {
     return ddLogLevel;
 }
 
-void WPSharedSetLoggingLevel(int level) {
+void WPSharedSetLoggingLevel(DDLogLevel level) {
     ddLogLevel = level;
 }

--- a/WordPressShared/Private/WPSharedLoggingPrivate.h
+++ b/WordPressShared/Private/WPSharedLoggingPrivate.h
@@ -1,2 +1,2 @@
 @import CocoaLumberjack;
-extern int ddLogLevel;
+extern DDLogLevel ddLogLevel;

--- a/WordPressShared/Private/WPSharedLoggingPrivate.m
+++ b/WordPressShared/Private/WPSharedLoggingPrivate.m
@@ -1,2 +1,2 @@
 #import "WPSharedLoggingPrivate.h"
-int ddLogLevel = DDLogLevelWarning;
+DDLogLevel ddLogLevel = DDLogLevelWarning;


### PR DESCRIPTION
Rather than using int as the type, we use DDLogLevel per https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/DynamicLogLevels.md.