### PR TITLE
Adds tracks for post reblogging

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.10"
+  s.version       = "1.8.11-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -374,6 +374,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatReaderArticleLiked,
     WPAnalyticsStatReaderArticleOpened,
     WPAnalyticsStatReaderArticleReblogged,
+    WPAnalyticsStatReaderArticleDetailReblogged,
     WPAnalyticsStatReaderArticleUnliked,
     WPAnalyticsStatReaderArticleDetailLiked,
     WPAnalyticsStatReaderArticleDetailUnliked,


### PR DESCRIPTION
This PR adds the key WPAnalyticsStatReaderArticleDetailReblogged for post reblogging

Feature ref. wordpress-mobile/WordPress-iOS/issues/12960

WPiOS PR: wordpress-mobile/WordPress-iOS/pull/13136