### PR TITLE
WPStyleGuide: ScaledFont now matches the requested weight

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.11"
+  s.version       = "1.8.12"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -180,12 +180,11 @@ extension WPStyleGuide {
     /// - Returns: the requested scaled font.
     ///
     private class func scaledFont(for style: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
-        let traitCollection = UITraitCollection(preferredContentSizeCategory: .large)
-        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: traitCollection)
-
+        let font = UIFont.preferredFont(forTextStyle: style)
         let traits = [UIFontDescriptor.TraitKey.weight: weight]
-        let descriptorWithTraits = descriptor.addingAttributes([.traits: traits])
-        let size = UIFontMetrics(forTextStyle: style).scaledValue(for: 0, compatibleWith: traitCollection)
+
+        let descriptorWithTraits = font.fontDescriptor.addingAttributes([.traits: traits])
+        let size = UIFontMetrics(forTextStyle: style).scaledValue(for: font.pointSize)
 
         return UIFont(descriptor: descriptorWithTraits, size: size)
     }

--- a/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -182,12 +182,12 @@ extension WPStyleGuide {
     private class func scaledFont(for style: UIFont.TextStyle, weight: UIFont.Weight) -> UIFont {
         let traitCollection = UITraitCollection(preferredContentSizeCategory: .large)
         let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: traitCollection)
-        
-        let traits = [UIFontDescriptor.TraitKey.weight: UIFont.Weight.semibold]
+
+        let traits = [UIFontDescriptor.TraitKey.weight: weight]
         let descriptorWithTraits = descriptor.addingAttributes([.traits: traits])
-        let baseFontWithTraits = UIFont(descriptor: descriptorWithTraits, size: 0)
-        
-        return UIFontMetrics(forTextStyle: style).scaledFont(for: baseFontWithTraits)
+        let size = UIFontMetrics(forTextStyle: style).scaledValue(for: 0, compatibleWith: traitCollection)
+
+        return UIFont(descriptor: descriptorWithTraits, size: size)
     }
 
     /// Creates a NotoSerif UIFont for the user current text size settings.


### PR DESCRIPTION
### Details:
In this PR we're fixing `WPStyleGuide.scaledFont` API, which wasn't properly returning a font with the requested weight.

### Testing:

**Please** verify this PR via [WordPress iOS PR 13152](https://github.com/wordpress-mobile/WordPress-iOS/pull/13152). Testing steps have been detailed there!
