### PR TITLE
Allow adjustment of Date display strings by Time Zone

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.12-beta.1"
+  s.version       = "1.8.12-beta.2"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Utility/NSDate+Helpers.swift
+++ b/WordPressShared/Core/Utility/NSDate+Helpers.swift
@@ -119,6 +119,7 @@ extension Date {
 
     /// Formats the current date as relative date if it's within a week of
     /// today, or with DateFormatter.Style.medium otherwise.
+    /// - Parameter timeZone: An optional time zone used to adjust the date formatters. **NOTE**: This has no affect on relative time stamps.
     ///
     /// - Example: 22 hours from now
     /// - Example: 5 minutes ago
@@ -126,9 +127,13 @@ extension Date {
     /// - Example: 2 days ago
     /// - Example: Jan 22, 2017
     ///
-    public func mediumString() -> String {
+    public func mediumString(timeZone: TimeZone? = nil) -> String {
         let relativeFormatter = TTTTimeIntervalFormatter()
         let absoluteFormatter = DateFormatters.mediumDate
+        
+        if let timeZone = timeZone {
+            absoluteFormatter.timeZone = timeZone
+        }
 
         let components = Calendar.current.dateComponents([.day], from: self, to: Date())
         if let days = components.day, abs(days) < 7 {
@@ -139,6 +144,7 @@ extension Date {
     }
 
     /// Formats the current date as a medium relative date/time.
+    /// - Parameter timeZone: An optional time zone used to adjust the date formatters.
     ///
     /// - Example: Tomorrow, 6:45 AM
     /// - Example: Today, 8:09 AM
@@ -146,8 +152,12 @@ extension Date {
     /// - Example: Jan 28, 2017, 1:51 PM
     /// - Example: Jan 22, 2017, 2:18 AM
     ///
-    public func mediumStringWithTime() -> String {
-        return DateFormatters.mediumDateTime.string(from: self)
+    public func mediumStringWithTime(timeZone: TimeZone? = nil) -> String {
+        let formatter = DateFormatters.mediumDateTime
+        if let timeZone = timeZone {
+            formatter.timeZone = timeZone
+        }
+        return formatter.string(from: self)
     }
 
     /// Formats the current date as (non relative) long date (no time) in UTC.

--- a/WordPressSharedTests/NSDateHelperTest.swift
+++ b/WordPressSharedTests/NSDateHelperTest.swift
@@ -33,4 +33,33 @@ class NSDateHelperTest: XCTestCase {
         XCTAssertEqual(components.month, data.month)
         XCTAssertEqual(components.day, data.day)
     }
+    
+    /// Verifies that `mediumString` produces relative format strings when less than 7 days have elapsed.
+    func testMediumStringRelativeString() {
+        let date = Date()
+        XCTAssertEqual(date.mediumString(), "just now")
+        XCTAssertEqual(date.addingTimeInterval(-60*5).mediumString(), "5 minutes ago")
+        XCTAssertEqual(date.addingTimeInterval(-60*60*2).mediumString(), "2 hours ago")
+        XCTAssertEqual(date.addingTimeInterval(-60*60*24).mediumString(), "1 day ago")
+        XCTAssertEqual(date.addingTimeInterval(-60*60*24*6).mediumString(), "6 days ago")
+    }
+    
+    /// Verifies that  `mediumStringWithTime` takes into account the time zone adjustment
+    func testMediumStringTimeZoneAdjust() {
+        let date = Date()
+        let timeZone = TimeZone(secondsFromGMT: Calendar.current.timeZone.secondsFromGMT() - (60 * 60))
+        XCTAssertEqual(date.mediumString(timeZone: timeZone), "just now")
+        
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .short
+        let withoutTimeZoneAdjust = timeFormatter.string(from: date)
+        
+        XCTAssertEqual(date.mediumStringWithTime(), "Today at \(withoutTimeZoneAdjust)")
+                
+        timeFormatter.timeZone = timeZone
+        let withTimeZoneAdjust = timeFormatter.string(from: date)
+        
+        XCTAssertEqual(date.mediumStringWithTime(timeZone: timeZone), "Today at \(withTimeZoneAdjust)")
+    }
 }


### PR DESCRIPTION
[WPiOS PR #13265](https://github.com/wordpress-mobile/WordPress-iOS/pull/13265#issue-366111364)

Addresses an issue with display strings for posts using the device instead of site time zone: https://github.com/wordpress-mobile/WordPress-iOS/issues/13258

Some additions to `NSDate+Helpers` to adjust the display string for a date based on an optional time zone. The default formatters use the device's time zone but we want to show the site time zone in many cases.

There is some performance penalty for this: about 2x as slow as not manipulating the time zone on the formatters. I think a cache could be added at some point but I'm not sure it's worth doing right now.

Added two tests:
- `testMediumStringRelativeString`: Ensures relative formats are shown. This is not new functionality.
- `testMediumStringTimeZoneAdjust`: Ensures methods are actually adjusting display strings by using the provided time zone.