### PR TITLE
Adds Web Preview analytics event

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.12-beta.2"
+  s.version       = "1.8.12-beta.3"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -290,6 +290,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatOpenedSupport,
     WPAnalyticsStatOpenedViewAdmin,
     WPAnalyticsStatOpenedViewSite,
+    WPAnalyticsStatOpenedWebPreview,
     WPAnalyticsStatPerformedCoreDataMigrationFixFor45,
     WPAnalyticsStatPersonUpdated,
     WPAnalyticsStatPersonRemoved,


### PR DESCRIPTION
[WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/13281)

Adds a `WPAnalyticsStatOpenedWebPreview` event to log when any post or page preview is opened.