### PR TITLE
Migrates some code to Swift. Strips Gutenberg galleries from summaries.

### DIFF
--- a/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared.xcodeproj/project.pbxproj
@@ -89,8 +89,14 @@
 		E1A444291F063CAB00F6AA8A /* WPAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A444271F063CAB00F6AA8A /* WPAnalytics.m */; };
 		F106FA61226FA72E00706DE4 /* StringURLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19847DD226F92EA0004A8BC /* StringURLValidationTests.swift */; };
 		F106FA62226FA82E00706DE4 /* String+URLValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19847DB226F92420004A8BC /* String+URLValidation.swift */; };
+		F10A569023E1FC1300B184F4 /* String+StripShortcodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A568F23E1FC1300B184F4 /* String+StripShortcodes.swift */; };
+		F10A569223E1FE7700B184F4 /* NSString+Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A569123E1FE7700B184F4 /* NSString+Summary.swift */; };
 		F1134A272270C15E00B8F75F /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1134A262270C15E00B8F75F /* Debouncer.swift */; };
 		F1134A292270C19200B8F75F /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1134A282270C19200B8F75F /* DebouncerTests.swift */; };
+		F1C83C0C23E205D900A8CCF1 /* NSStringSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */; };
+		F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */; };
+		F1C83C1023E20EF200A8CCF1 /* String+ReplacingMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */; };
+		F1C83C1223E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */; };
 		FF20AD1D20B83EDB00082398 /* WordPressShared.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */; };
 /* End PBXBuildFile section */
 
@@ -201,10 +207,16 @@
 		E1A444261F063CAB00F6AA8A /* WPAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAnalytics.h; sourceTree = "<group>"; };
 		E1A444271F063CAB00F6AA8A /* WPAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAnalytics.m; sourceTree = "<group>"; };
 		E5A4545AEF641B125A2ABA89 /* Pods-WordPressShared.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShared.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressShared/Pods-WordPressShared.debug.xcconfig"; sourceTree = "<group>"; };
+		F10A568F23E1FC1300B184F4 /* String+StripShortcodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripShortcodes.swift"; sourceTree = "<group>"; };
+		F10A569123E1FE7700B184F4 /* NSString+Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+Summary.swift"; sourceTree = "<group>"; };
 		F1134A262270C15E00B8F75F /* Debouncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		F1134A282270C19200B8F75F /* DebouncerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		F19847DB226F92420004A8BC /* String+URLValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLValidation.swift"; sourceTree = "<group>"; };
 		F19847DD226F92EA0004A8BC /* StringURLValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringURLValidationTests.swift; sourceTree = "<group>"; };
+		F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSStringSummaryTests.swift; sourceTree = "<group>"; };
+		F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripGutenbergContentForExcerpt.swift"; sourceTree = "<group>"; };
+		F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ReplacingMatches.swift"; sourceTree = "<group>"; };
+		F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringStripGutenbergContentForExcerptTests.swift; sourceTree = "<group>"; };
 		FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressShared.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
@@ -295,6 +307,7 @@
 				74650F7F1F0EA4BD00188EDB /* NSMutableData+Helpers.swift */,
 				74650F791F0EA2FA00188EDB /* NSString+Helpers.h */,
 				74650F7A1F0EA2FA00188EDB /* NSString+Helpers.m */,
+				F10A569123E1FE7700B184F4 /* NSString+Summary.swift */,
 				B5393FED206D7829007BF9D4 /* NSString+Swift.swift */,
 				82706FF61ECA43AA00155CBF /* NSString+Util.h */,
 				82706FF51ECA43AA00155CBF /* NSString+Util.m */,
@@ -305,6 +318,9 @@
 				7430C9DA1F1933F40051B8E6 /* RichContentFormatter.swift */,
 				E157E125239527700051AE41 /* Secret.swift */,
 				7414BD541F13CBE0005759F8 /* String+Helpers.swift */,
+				F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */,
+				F10A568F23E1FC1300B184F4 /* String+StripShortcodes.swift */,
+				F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */,
 				F19847DB226F92420004A8BC /* String+URLValidation.swift */,
 				7414BD5F1F13D084005759F8 /* UIDevice+Helpers.h */,
 				7414BD601F13D084005759F8 /* UIDevice+Helpers.m */,
@@ -342,9 +358,11 @@
 				93AB05FC1EE8405A00EF8764 /* LanguagesTests.swift */,
 				B5393FEF206D7862007BF9D4 /* NSStringSwiftTests.m */,
 				74D44ED81F0EC6230075F96B /* NSStringHelpersTests.m */,
+				F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */,
 				7430C9D41F1930460051B8E6 /* PhotonImageURLHelperTest.m */,
 				7430C9DC1F1934190051B8E6 /* RichContentFormatterTests.swift */,
 				748710AB1F06C465008095AB /* StringHelperTests.swift */,
+				F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */,
 				E18EABE71F0E2C6800BFCB0B /* TestAnalyticsTracker.h */,
 				E18EABE81F0E2C6800BFCB0B /* TestAnalyticsTracker.m */,
 				E18EABE91F0E2C6800BFCB0B /* WPAnalyticsTests.m */,
@@ -671,6 +689,7 @@
 				B5A78816202B3A55007874FB /* WPStyleGuide+DynamicType.swift in Sources */,
 				7414BD561F13CBE0005759F8 /* String+Helpers.swift in Sources */,
 				827070031ECA43AA00155CBF /* NSString+Util.m in Sources */,
+				F1C83C1023E20EF200A8CCF1 /* String+ReplacingMatches.swift in Sources */,
 				82706FF41ECA438500155CBF /* WPSharedLoggingPrivate.m in Sources */,
 				7430C9E11F1935400051B8E6 /* WPImageURLHelper.swift in Sources */,
 				B5A78813202B3A55007874FB /* WPStyleGuide.m in Sources */,
@@ -679,15 +698,18 @@
 				7430C9D31F19302D0051B8E6 /* PhotonImageURLHelper.m in Sources */,
 				7414BD5A1F13CEA5005759F8 /* NSBundle+VersionNumberHelper.m in Sources */,
 				827070061ECA43AA00155CBF /* NSString+XMLExtensions.m in Sources */,
+				F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */,
 				82706FF31ECA438500155CBF /* WPSharedLogging.m in Sources */,
 				F1134A272270C15E00B8F75F /* Debouncer.swift in Sources */,
 				B5393FD8206D608F007BF9D4 /* EmailFormatValidator.swift in Sources */,
 				F106FA62226FA82E00706DE4 /* String+URLValidation.swift in Sources */,
+				F10A569023E1FC1300B184F4 /* String+StripShortcodes.swift in Sources */,
 				93C882AD1EEB1E2F00227A59 /* NSDate+Helpers.swift in Sources */,
 				74650F801F0EA4BD00188EDB /* NSMutableData+Helpers.swift in Sources */,
 				7414BD621F13D084005759F8 /* UIDevice+Helpers.m in Sources */,
 				B5A787E9202B2BD4007874FB /* WPFontManager.m in Sources */,
 				B5393FD9206D608F007BF9D4 /* EmailTypoChecker.swift in Sources */,
+				F10A569223E1FE7700B184F4 /* NSString+Summary.swift in Sources */,
 				740B23CD1F17F1FF00067A2A /* DisplayableImageHelper.m in Sources */,
 				B5A78818202B3A55007874FB /* WPNUXUtility.m in Sources */,
 				7430C9DB1F1933F40051B8E6 /* RichContentFormatter.swift in Sources */,
@@ -707,12 +729,14 @@
 				B5393FF0206D7863007BF9D4 /* NSStringSwiftTests.m in Sources */,
 				827070931ECA4E1D00155CBF /* WPImageSourceTest.m in Sources */,
 				E18EABEA1F0E2C6800BFCB0B /* TestAnalyticsTracker.m in Sources */,
+				F1C83C1223E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift in Sources */,
 				93AB05FD1EE8405A00EF8764 /* LanguagesTests.swift in Sources */,
 				B5393FDD206D6169007BF9D4 /* EmailTypoCheckerTests.swift in Sources */,
 				F1134A292270C19200B8F75F /* DebouncerTests.swift in Sources */,
 				7430C9D51F1930460051B8E6 /* PhotonImageURLHelperTest.m in Sources */,
 				E157E128239527AD0051AE41 /* SecretTests.swift in Sources */,
 				740B23CF1F17F28E00067A2A /* DisplayableImageHelperTest.m in Sources */,
+				F1C83C0C23E205D900A8CCF1 /* NSStringSummaryTests.swift in Sources */,
 				E18EABEB1F0E2C6800BFCB0B /* WPAnalyticsTests.m in Sources */,
 				7430C9DD1F1934190051B8E6 /* RichContentFormatterTests.swift in Sources */,
 				B5393FDC206D6169007BF9D4 /* EmailFormatValidatorTests.swift in Sources */,

--- a/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 		F1134A292270C19200B8F75F /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1134A282270C19200B8F75F /* DebouncerTests.swift */; };
 		F1C83C0C23E205D900A8CCF1 /* NSStringSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */; };
 		F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */; };
-		F1C83C1023E20EF200A8CCF1 /* String+ReplacingMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */; };
+		F1C83C1023E20EF200A8CCF1 /* String+RemovingMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */; };
 		F1C83C1223E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */; };
 		FF20AD1D20B83EDB00082398 /* WordPressShared.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */; };
 /* End PBXBuildFile section */
@@ -215,7 +215,7 @@
 		F19847DD226F92EA0004A8BC /* StringURLValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringURLValidationTests.swift; sourceTree = "<group>"; };
 		F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSStringSummaryTests.swift; sourceTree = "<group>"; };
 		F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripGutenbergContentForExcerpt.swift"; sourceTree = "<group>"; };
-		F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ReplacingMatches.swift"; sourceTree = "<group>"; };
+		F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+RemovingMatches.swift"; sourceTree = "<group>"; };
 		F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringStripGutenbergContentForExcerptTests.swift; sourceTree = "<group>"; };
 		FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressShared.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
@@ -318,7 +318,7 @@
 				7430C9DA1F1933F40051B8E6 /* RichContentFormatter.swift */,
 				E157E125239527700051AE41 /* Secret.swift */,
 				7414BD541F13CBE0005759F8 /* String+Helpers.swift */,
-				F1C83C0F23E20EF200A8CCF1 /* String+ReplacingMatches.swift */,
+				F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */,
 				F10A568F23E1FC1300B184F4 /* String+StripShortcodes.swift */,
 				F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */,
 				F19847DB226F92420004A8BC /* String+URLValidation.swift */,
@@ -689,7 +689,7 @@
 				B5A78816202B3A55007874FB /* WPStyleGuide+DynamicType.swift in Sources */,
 				7414BD561F13CBE0005759F8 /* String+Helpers.swift in Sources */,
 				827070031ECA43AA00155CBF /* NSString+Util.m in Sources */,
-				F1C83C1023E20EF200A8CCF1 /* String+ReplacingMatches.swift in Sources */,
+				F1C83C1023E20EF200A8CCF1 /* String+RemovingMatches.swift in Sources */,
 				82706FF41ECA438500155CBF /* WPSharedLoggingPrivate.m in Sources */,
 				7430C9E11F1935400051B8E6 /* WPImageURLHelper.swift in Sources */,
 				B5A78813202B3A55007874FB /* WPStyleGuide.m in Sources */,

--- a/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */; };
 		F1C83C1023E20EF200A8CCF1 /* String+RemovingMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */; };
 		F1C83C1223E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */; };
+		F1E214C123E3690E00A2CA73 /* StringRemovingMatchesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E214C023E3690E00A2CA73 /* StringRemovingMatchesTests.swift */; };
 		FF20AD1D20B83EDB00082398 /* WordPressShared.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */; };
 /* End PBXBuildFile section */
 
@@ -217,6 +218,7 @@
 		F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+StripGutenbergContentForExcerpt.swift"; sourceTree = "<group>"; };
 		F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+RemovingMatches.swift"; sourceTree = "<group>"; };
 		F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringStripGutenbergContentForExcerptTests.swift; sourceTree = "<group>"; };
+		F1E214C023E3690E00A2CA73 /* StringRemovingMatchesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRemovingMatchesTests.swift; sourceTree = "<group>"; };
 		FF20AD1C20B83EDB00082398 /* WordPressShared.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressShared.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
@@ -362,6 +364,7 @@
 				7430C9D41F1930460051B8E6 /* PhotonImageURLHelperTest.m */,
 				7430C9DC1F1934190051B8E6 /* RichContentFormatterTests.swift */,
 				748710AB1F06C465008095AB /* StringHelperTests.swift */,
+				F1E214C023E3690E00A2CA73 /* StringRemovingMatchesTests.swift */,
 				F1C83C1123E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift */,
 				E18EABE71F0E2C6800BFCB0B /* TestAnalyticsTracker.h */,
 				E18EABE81F0E2C6800BFCB0B /* TestAnalyticsTracker.m */,
@@ -732,6 +735,7 @@
 				F1C83C1223E20F7000A8CCF1 /* StringStripGutenbergContentForExcerptTests.swift in Sources */,
 				93AB05FD1EE8405A00EF8764 /* LanguagesTests.swift in Sources */,
 				B5393FDD206D6169007BF9D4 /* EmailTypoCheckerTests.swift in Sources */,
+				F1E214C123E3690E00A2CA73 /* StringRemovingMatchesTests.swift in Sources */,
 				F1134A292270C19200B8F75F /* DebouncerTests.swift in Sources */,
 				7430C9D51F1930460051B8E6 /* PhotonImageURLHelperTest.m in Sources */,
 				E157E128239527AD0051AE41 /* SecretTests.swift in Sources */,

--- a/WordPressShared/Core/Utility/NSString+Helpers.h
+++ b/WordPressShared/Core/Utility/NSString+Helpers.h
@@ -3,28 +3,12 @@
 @interface NSString (Helpers)
 
 /**
- Transforms the specified string to plain text.  HTML markup is removed and HTML entities are decoded.
-
- @param string The string to transform.
- @return The transformed string.
- */
-//+ (NSString *)makePlainText:(NSString *)string;
-
-/**
  Removes shortcodes from the passed string.
 
  @param string The string to remove shortcodes from.
  @return The modified string.
  */
 + (NSString *)stripShortcodesFromString:(NSString *)string;
-
-/**
- Create a summary for the post based on the post's content.
-
- @param string The post's content string. This should be the formatted content string.
- @return A summary for the post.
- */
-//+ (NSString *)summaryFromContent:(NSString *)string;
 
 - (NSString *)stringByUrlEncoding;
 - (NSMutableDictionary *)dictionaryFromQueryString;

--- a/WordPressShared/Core/Utility/NSString+Helpers.h
+++ b/WordPressShared/Core/Utility/NSString+Helpers.h
@@ -8,7 +8,7 @@
  @param string The string to transform.
  @return The transformed string.
  */
-+ (NSString *)makePlainText:(NSString *)string;
+//+ (NSString *)makePlainText:(NSString *)string;
 
 /**
  Removes shortcodes from the passed string.
@@ -24,7 +24,7 @@
  @param string The post's content string. This should be the formatted content string.
  @return A summary for the post.
  */
-+ (NSString *)summaryFromContent:(NSString *)string;
+//+ (NSString *)summaryFromContent:(NSString *)string;
 
 - (NSString *)stringByUrlEncoding;
 - (NSMutableDictionary *)dictionaryFromQueryString;

--- a/WordPressShared/Core/Utility/NSString+Helpers.m
+++ b/WordPressShared/Core/Utility/NSString+Helpers.m
@@ -3,7 +3,6 @@
 #import "WPSharedLoggingPrivate.h"
 #import "NSString+XMLExtensions.h"
 
-//static const NSUInteger PostDerivedSummaryLength = 150;
 static NSString *const Ellipsis =  @"\u2026";
 
 @implementation NSString (Helpers)
@@ -84,14 +83,6 @@ static NSString *const Ellipsis =  @"\u2026";
     return [[NSString alloc] initWithBytes:&hex length:4 encoding:NSUTF32LittleEndianStringEncoding];
 }
 
-/*
-+ (NSString *)makePlainText:(NSString *)string
-{
-    NSCharacterSet *charSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
-    return [[[string stringByStrippingHTML] stringByDecodingXMLCharacters] stringByTrimmingCharactersInSet:charSet];
-}
- */
-
 + (NSString *)stripShortcodesFromString:(NSString *)string
 {
     if (!string) {
@@ -113,15 +104,6 @@ static NSString *const Ellipsis =  @"\u2026";
                                              range:range
                                       withTemplate:@""];
 }
-/*
-+ (NSString *)summaryFromContent:(NSString *)string
-{
-    string = [NSString makePlainText:string];
-    string = [NSString stripShortcodesFromString:string];
-    string = [string stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\n"]];
-    return [string stringByEllipsizingWithMaxLength:PostDerivedSummaryLength preserveWords:YES];
-}
- */
 
 // Taken from AFNetworking's AFPercentEscapedQueryStringPairMemberFromStringWithEncoding
 - (NSString *)stringByUrlEncoding

--- a/WordPressShared/Core/Utility/NSString+Helpers.m
+++ b/WordPressShared/Core/Utility/NSString+Helpers.m
@@ -3,7 +3,7 @@
 #import "WPSharedLoggingPrivate.h"
 #import "NSString+XMLExtensions.h"
 
-static const NSUInteger PostDerivedSummaryLength = 150;
+//static const NSUInteger PostDerivedSummaryLength = 150;
 static NSString *const Ellipsis =  @"\u2026";
 
 @implementation NSString (Helpers)
@@ -84,11 +84,13 @@ static NSString *const Ellipsis =  @"\u2026";
     return [[NSString alloc] initWithBytes:&hex length:4 encoding:NSUTF32LittleEndianStringEncoding];
 }
 
+/*
 + (NSString *)makePlainText:(NSString *)string
 {
     NSCharacterSet *charSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
     return [[[string stringByStrippingHTML] stringByDecodingXMLCharacters] stringByTrimmingCharactersInSet:charSet];
 }
+ */
 
 + (NSString *)stripShortcodesFromString:(NSString *)string
 {
@@ -111,7 +113,7 @@ static NSString *const Ellipsis =  @"\u2026";
                                              range:range
                                       withTemplate:@""];
 }
-
+/*
 + (NSString *)summaryFromContent:(NSString *)string
 {
     string = [NSString makePlainText:string];
@@ -119,6 +121,7 @@ static NSString *const Ellipsis =  @"\u2026";
     string = [string stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"\n"]];
     return [string stringByEllipsizingWithMaxLength:PostDerivedSummaryLength preserveWords:YES];
 }
+ */
 
 // Taken from AFNetworking's AFPercentEscapedQueryStringPairMemberFromStringWithEncoding
 - (NSString *)stringByUrlEncoding

--- a/WordPressShared/Core/Utility/NSString+Summary.swift
+++ b/WordPressShared/Core/Utility/NSString+Summary.swift
@@ -7,7 +7,9 @@ extension NSString {
     
     static let PostDerivedSummaryLength = 150
     
-    /// Summarizes HTML content.
+    /// Create a summary for the post based on the post's content.
+    ///
+    /// - Returns: A summary for the post.
     ///
     @objc
     public func summarized() -> String {
@@ -21,6 +23,10 @@ extension NSString {
     }
     
     /// Converts HTML content into plain text by stripping HTML tags and decodinig XML chars.
+    /// Transforms the specified string to plain text.  HTML markup is removed and HTML entities are decoded.
+    ///
+    /// - Returns: The transformed string.
+    ///
     @objc
     public func makePlainText() -> String {
         let characterSet = NSCharacterSet.whitespacesAndNewlines

--- a/WordPressShared/Core/Utility/NSString+Summary.swift
+++ b/WordPressShared/Core/Utility/NSString+Summary.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// This is an extension to NSString that provides logic to summarize HTML content,
+/// and convert HTML into plain text.
+///
+extension NSString {
+    
+    static let PostDerivedSummaryLength = 150
+    
+    /// Summarizes HTML content.
+    ///
+    @objc
+    public func summarized() -> String {
+        let characterSet = CharacterSet(charactersIn: "\n")
+        
+        return (self as String).strippingGutenbergContentForExcerpt()
+            .strippingShortcodes()
+            .makePlainText()
+            .trimmingCharacters(in: characterSet)
+            .ellipsizing(withMaxLength: NSString.PostDerivedSummaryLength, preserveWords: true)
+    }
+    
+    /// Converts HTML content into plain text by stripping HTML tags and decodinig XML chars.
+    @objc
+    public func makePlainText() -> String {
+        let characterSet = NSCharacterSet.whitespacesAndNewlines
+        
+        return strippingHTML()
+            .decodingXMLCharacters()
+            .trimmingCharacters(in: characterSet)
+    }
+}

--- a/WordPressShared/Core/Utility/String+RemovingMatches.swift
+++ b/WordPressShared/Core/Utility/String+RemovingMatches.swift
@@ -2,7 +2,9 @@ import Foundation
 
 extension String {
     
-    func replacingMatches(_ regex: NSRegularExpression) -> String {
+    /// Creates a new string by removing all matches of the specified regex.
+    ///
+    func removingMatches(_ regex: NSRegularExpression) -> String {
         let range = NSRange(location: 0, length: self.utf16.count)
         
         return regex.stringByReplacingMatches(in: self, options: .reportCompletion, range: range, withTemplate: "")

--- a/WordPressShared/Core/Utility/String+RemovingMatches.swift
+++ b/WordPressShared/Core/Utility/String+RemovingMatches.swift
@@ -4,8 +4,16 @@ extension String {
     
     /// Creates a new string by removing all matches of the specified regex.
     ///
-    func removingMatches(_ regex: NSRegularExpression) -> String {
+    func removingMatches(pattern: String) -> String {
         let range = NSRange(location: 0, length: self.utf16.count)
+        let regex: NSRegularExpression
+        
+        do {
+            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        } catch {
+            DDLogError(("Error parsing regex: \(error)"))
+            return self
+        }
         
         return regex.stringByReplacingMatches(in: self, options: .reportCompletion, range: range, withTemplate: "")
     }

--- a/WordPressShared/Core/Utility/String+RemovingMatches.swift
+++ b/WordPressShared/Core/Utility/String+RemovingMatches.swift
@@ -4,12 +4,12 @@ extension String {
     
     /// Creates a new string by removing all matches of the specified regex.
     ///
-    func removingMatches(pattern: String) -> String {
+    func removingMatches(pattern: String, options: NSRegularExpression.Options = []) -> String {
         let range = NSRange(location: 0, length: self.utf16.count)
         let regex: NSRegularExpression
         
         do {
-            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            regex = try NSRegularExpression(pattern: pattern, options: options)
         } catch {
             DDLogError(("Error parsing regex: \(error)"))
             return self

--- a/WordPressShared/Core/Utility/String+ReplacingMatches.swift
+++ b/WordPressShared/Core/Utility/String+ReplacingMatches.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+    
+    func replacingMatches(_ regex: NSRegularExpression) -> String {
+        let range = NSRange(location: 0, length: self.utf16.count)
+        
+        return regex.stringByReplacingMatches(in: self, options: .reportCompletion, range: range, withTemplate: "")
+    }
+}

--- a/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -15,15 +15,7 @@ extension String {
     ///
     private func strippingGutenbergGalleries() -> String {
         let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
-        let regex: NSRegularExpression
         
-        do {
-            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-        } catch {
-            DDLogError(("Error parsing regex: \(error)"))
-            return self
-        }
-        
-        return removingMatches(regex)
+        return removingMatches(pattern: pattern)
     }
 }

--- a/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// This extension provides logic for stripping some Gutenberg content that should not be
+/// shown when generating post excerpts.
+///
+extension String {
+    
+    /// This method is the main entry point to generate excerpts for Gutenberg content.
+    ///
+    public func strippingGutenbergContentForExcerpt() -> String {
+        return strippingGutenbergGalleries()
+    }
+    
+    /// Strips Gutenberg galleries from strings.
+    ///
+    private func strippingGutenbergGalleries() -> String {
+        let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
+        let regex: NSRegularExpression
+        
+        do {
+            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        } catch {
+            DDLogError(("Error parsing regex: \(error)"))
+            return self
+        }
+        
+        return replacingMatches(regex)
+    }
+}

--- a/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -24,6 +24,6 @@ extension String {
             return self
         }
         
-        return replacingMatches(regex)
+        return removingMatches(regex)
     }
 }

--- a/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -16,6 +16,6 @@ extension String {
     private func strippingGutenbergGalleries() -> String {
         let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
         
-        return removingMatches(pattern: pattern)
+        return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
 }

--- a/WordPressShared/Core/Utility/String+StripShortcodes.swift
+++ b/WordPressShared/Core/Utility/String+StripShortcodes.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension String {
+    
+    func strippingShortcodes() -> String {
+        let pattern = "\\[[^\\]]+\\]"
+        let regex: NSRegularExpression
+        
+        do {
+            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        } catch {
+            DDLogError(("Error parsing regex: \(error)"))
+            return self
+        }
+        
+        return replacingMatches(regex)
+    }
+}

--- a/WordPressShared/Core/Utility/String+StripShortcodes.swift
+++ b/WordPressShared/Core/Utility/String+StripShortcodes.swift
@@ -7,6 +7,6 @@ extension String {
     func strippingShortcodes() -> String {
         let pattern = "\\[[^\\]]+\\]"
         
-        return removingMatches(pattern: pattern)
+        return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
 }

--- a/WordPressShared/Core/Utility/String+StripShortcodes.swift
+++ b/WordPressShared/Core/Utility/String+StripShortcodes.swift
@@ -2,6 +2,8 @@ import Foundation
 
 extension String {
     
+    /// Creates a new string by stripping all shortcodes from this string.
+    ///
     func strippingShortcodes() -> String {
         let pattern = "\\[[^\\]]+\\]"
         let regex: NSRegularExpression
@@ -13,6 +15,6 @@ extension String {
             return self
         }
         
-        return replacingMatches(regex)
+        return removingMatches(regex)
     }
 }

--- a/WordPressShared/Core/Utility/String+StripShortcodes.swift
+++ b/WordPressShared/Core/Utility/String+StripShortcodes.swift
@@ -6,15 +6,7 @@ extension String {
     ///
     func strippingShortcodes() -> String {
         let pattern = "\\[[^\\]]+\\]"
-        let regex: NSRegularExpression
         
-        do {
-            regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-        } catch {
-            DDLogError(("Error parsing regex: \(error)"))
-            return self
-        }
-        
-        return removingMatches(regex)
+        return removingMatches(pattern: pattern)
     }
 }

--- a/WordPressSharedTests/NSStringHelpersTests.m
+++ b/WordPressSharedTests/NSStringHelpersTests.m
@@ -186,13 +186,4 @@
     XCTAssertTrue([expectedString isEqualToString:[sourceString stringByNormalizingWhitespace]]);
 }
 
-- (void)testSummaryForContent
-{
-    NSString *content = @"<p>Lorem ipsum dolor sit amet, [shortcode param=\"value\"]consectetur[/shortcode] adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p><p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>";
-    NSString *summary = [NSString summaryFromContent:content];
-    NSString *expectedSummary = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, …";
-
-    XCTAssertTrue([summary isEqualToString:expectedSummary], @"The expected summary was not derived from the content.");
-}
-
 @end

--- a/WordPressSharedTests/NSStringSummaryTests.swift
+++ b/WordPressSharedTests/NSStringSummaryTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WordPressShared
+
+class NSStringSummaryTests: XCTestCase {
+
+    func testSummaryForContent() {
+        let content = "<p>Lorem ipsum dolor sit amet, [shortcode param=\"value\"]consectetur[/shortcode] adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p><p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"
+        let expectedSummary = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, …"
+        
+        let summary = content.summarized()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+    
+    func testSummaryForContentWithGallery() {
+        let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
+        let expectedSummary = "Some Content"
+        
+        let summary = content.summarized()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+    
+    func testSummaryForContentWithGallery2() {
+        let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
+        let expectedSummary = "Before\nAfter"
+        
+        let summary = content.summarized()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+}

--- a/WordPressSharedTests/StringRemovingMatchesTests.swift
+++ b/WordPressSharedTests/StringRemovingMatchesTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import WordPressShared
+
+class StringRemovingMatchesTests: XCTestCase {
+    
+    func testStringRemovingMatches() {
+        let initial = "<p>Some Content</p>"
+        let pattern = "<p>"
+        let expected = "Some Content</p>"
+        
+        let final = initial.removingMatches(pattern: pattern)
+        
+        XCTAssertEqual(final, expected)
+    }
+    
+    func testStringRemovingMatchesWithEmojis() {
+        let initial = "🌎world🌎"
+        let pattern = "🌎"
+        let expected = "world"
+        
+        let final = initial.removingMatches(pattern: pattern)
+        
+        XCTAssertEqual(final, expected)
+    }
+    
+    func testStringRemovingMatchesWithEmojis2() {
+        let initial = "🌎world🌎"
+        let pattern = "world"
+        let expected = "🌎🌎"
+        
+        let final = initial.removingMatches(pattern: pattern)
+        
+        XCTAssertEqual(final, expected)
+    }
+}

--- a/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -3,7 +3,16 @@ import XCTest
 
 class StringStripGutenbergContentForExcerptTests: XCTestCase {
     
-    func testSummaryForContentWithGallery() {
+    func testStrippingGutenbergContentForExcerpt() {
+        let content = "<p>Some Content</p>"
+        let expectedSummary = "<p>Some Content</p>"
+        
+        let summary = content.strippingGutenbergContentForExcerpt()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+    
+    func testStrippingGutenbergContentForExcerptWithGallery() {
         let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
         let expectedSummary = "<p>Some Content</p>"
         
@@ -12,7 +21,7 @@ class StringStripGutenbergContentForExcerptTests: XCTestCase {
         XCTAssertEqual(summary, expectedSummary)
     }
     
-    func testSummaryForContentWithGallery2() {
+    func testStrippingGutenbergContentForExcerptWithGallery2() {
         let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
         let expectedSummary = "<p>Before</p>\n<p>After</p>"
         

--- a/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import WordPressShared
+
+class StringStripGutenbergContentForExcerptTests: XCTestCase {
+    
+    func testSummaryForContentWithGallery() {
+        let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
+        let expectedSummary = "<p>Some Content</p>"
+        
+        let summary = content.strippingGutenbergContentForExcerpt()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+    
+    func testSummaryForContentWithGallery2() {
+        let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
+        let expectedSummary = "<p>Before</p>\n<p>After</p>"
+        
+        let summary = content.strippingGutenbergContentForExcerpt()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
+}


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/13154

This PR improves the existing code, adds tests, and implements logic to strip Gutenberg Galleries from excerpts.

## Changes:

- Migrates some of our existing code to Swift.
- Adds support for stripping Gutenberg Galleries from post excerpts.
- Adds unit tests to validate the logic.

## Associated branches:

WordPress-iOS test branch: `issue/13154-remove-gallery-captions-from-excerpts`
WordPress-Kit test branch: `issue/wpios-13154-strip-gutenberg-galleries`

## Testing:

### Test 1:

Run the unit tests.

### Test 2:

Check out the associated branches and run the unit tests.

### Test 3:

Run the WPiOS associated branch and follow the testing steps detailed in this issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/13154

This is what you should see:

![testingExcerpts](https://user-images.githubusercontent.com/1836005/73487139-25ac9480-4385-11ea-95d9-60ead5b57d22.gif)
