### PR TITLE
Adding track for widget site change.

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.12"
+  s.version       = "1.8.13-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -564,6 +564,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatTwoFactorSentSMS,
     WPAnalyticsStatShareExtensionError,
     WPAnalyticsStatSearchAdsAttribution,
+    WPAnalyticsStatWidgetActiveSiteChanged,
     WPAnalyticsStatMaxValue,
     /// Logged when there are orphaned entities (e.g. has NULL blog values).
     ///


### PR DESCRIPTION
This adds a track for when the site used for Stats widgets changes.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13324