### PR TITLE
Add Session Template keys for SPT metrics on template selection

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.8.13"
+  s.version       = "1.8.14-beta.2"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -110,6 +110,8 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEditorSessionStart,
     WPAnalyticsStatEditorSessionSwitchEditor,
     WPAnalyticsStatEditorSessionEnd,
+    WPAnalyticsStatEditorSessionTemplateApply,
+    WPAnalyticsStatEditorSessionTemplatePreview,
     WPAnalyticsStatEditorTappedItalic,
     WPAnalyticsStatEditorTappedLink,
     WPAnalyticsStatEditorTappedMore,


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/1883
**Related PRs:**
- `gutenberg` https://github.com/WordPress/gutenberg/pull/20317
- `gutenberg-mobile iOS and JS` https://github.com/wordpress-mobile/gutenberg-mobile/pull/1936
- `WordPress-iOS` https://github.com/wordpress-mobile/WordPress-iOS/pull/13510
- `WordPress-iOS-Shared` https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/250
- `gutenberg-mobile Android` https://github.com/wordpress-mobile/gutenberg-mobile/pull/1945
- `WordPress-Android` https://github.com/wordpress-mobile/WordPress-Android/pull/11362

---

This change adds two track events for SPT selections.  

### WPAnalyticsStatEditorSessionTemplatePreview 
Event: `editor_session_template_preview`
1) Open iOS app
2) Navigate to Pages
3) Create a new page
4) Select a pre-defined template
5) Close or Apply and exit

**Expect** to see the event `editor_session_template_preview` registered with the `template` property populated with the name of the selected template.

### WPAnalyticsStatEditorSessionTemplateApply 
Event: `editor_session_template_apply`
1) Open iOS app
2) Navigate to Pages
3) Create a new page
4) Select a pre-defined template
5) Close or Apply and exit

**Expect** to see the event `editor_session_template_apply` registered with the `template` property populated with the name of the selected template.

These changes can be tested with https://github.com/wordpress-mobile/WordPress-iOS/pull/13510