### PR TITLE
Implements a new mechanism for analytics event tracking.

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.9.2-beta.1"
+  s.version       = "1.10.0-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		F10A569223E1FE7700B184F4 /* NSString+Summary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A569123E1FE7700B184F4 /* NSString+Summary.swift */; };
 		F1134A272270C15E00B8F75F /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1134A262270C15E00B8F75F /* Debouncer.swift */; };
 		F1134A292270C19200B8F75F /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1134A282270C19200B8F75F /* DebouncerTests.swift */; };
+		F193585624CA3F4E00942507 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F193585524CA3F4E00942507 /* AnalyticsEvent.swift */; };
 		F1C83C0C23E205D900A8CCF1 /* NSStringSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */; };
 		F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0D23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift */; };
 		F1C83C1023E20EF200A8CCF1 /* String+RemovingMatches.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C83C0F23E20EF200A8CCF1 /* String+RemovingMatches.swift */; };
@@ -214,6 +215,7 @@
 		F10A569123E1FE7700B184F4 /* NSString+Summary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+Summary.swift"; sourceTree = "<group>"; };
 		F1134A262270C15E00B8F75F /* Debouncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		F1134A282270C19200B8F75F /* DebouncerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
+		F193585524CA3F4E00942507 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		F19847DB226F92420004A8BC /* String+URLValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+URLValidation.swift"; sourceTree = "<group>"; };
 		F19847DD226F92EA0004A8BC /* StringURLValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringURLValidationTests.swift; sourceTree = "<group>"; };
 		F1C83C0B23E205D900A8CCF1 /* NSStringSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSStringSummaryTests.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 		E1A444251F063CAB00F6AA8A /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				F193585524CA3F4E00942507 /* AnalyticsEvent.swift */,
 				E1A444261F063CAB00F6AA8A /* WPAnalytics.h */,
 				E1A444271F063CAB00F6AA8A /* WPAnalytics.m */,
 			);
@@ -706,6 +709,7 @@
 				827070061ECA43AA00155CBF /* NSString+XMLExtensions.m in Sources */,
 				F1C83C0E23E20D9400A8CCF1 /* String+StripGutenbergContentForExcerpt.swift in Sources */,
 				82706FF31ECA438500155CBF /* WPSharedLogging.m in Sources */,
+				F193585624CA3F4E00942507 /* AnalyticsEvent.swift in Sources */,
 				F1134A272270C15E00B8F75F /* Debouncer.swift in Sources */,
 				B5393FD8206D608F007BF9D4 /* EmailFormatValidator.swift in Sources */,
 				F106FA62226FA82E00706DE4 /* String+URLValidation.swift in Sources */,

--- a/WordPressShared/Core/Analytics/AnalyticsEvent.swift
+++ b/WordPressShared/Core/Analytics/AnalyticsEvent.swift
@@ -48,10 +48,6 @@ public final class AnalyticsEvent {
     }
 }
 
-extension AnalyticsEvent {
-    static let loginStart = AnalyticsEvent(name: "login", properties: ["step": "start"])
-}
-
 extension WPAnalytics {
     public static func track(_ event: AnalyticsEvent) {
         WPAnalytics.trackString(event.name, withProperties: event.properties)

--- a/WordPressShared/Core/Analytics/AnalyticsEvent.swift
+++ b/WordPressShared/Core/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// This struct represents an analytics event.
+/// Declaring this class as final is a design choice to promote a simpler usage and implement events
+/// through parametrization of the `name` and `properties`.
+///
+/// An example of a static event definition:
+///
+/// ~~~
+/// extension AnalyticsEvent {
+///     static let loginStart = AnalyticsEvent(name: "login", properties: ["step": "start"])
+/// }
+/// ~~~
+///
+/// An example of a dynamic / parametrized event definition:
+///
+/// ~~~
+/// extension AnalyticsEvent {
+///     enum LoginStep: String {
+///         case start
+///         case success
+///     }
+///
+///     static func login(step: LoginStep) -> AnalyticsEvent {
+///         let properties = [
+///             "step": step.rawValue
+///         ]
+///
+///         return AnalyticsEvent(name: "login", properties: properties)
+///     }
+/// }
+/// ~~~
+///
+/// Examples of tracking calls:
+///
+/// ~~~
+/// WPAnalytics.track(.login(step: .start))
+/// WPAnalytics.track(.loginStart)
+/// ~~~
+///
+public final class AnalyticsEvent {
+    let name: String
+    let properties: [String: String]
+
+    public init(name: String, properties: [String: String]) {
+        self.name = name
+        self.properties = properties
+    }
+}
+
+extension AnalyticsEvent {
+    static let loginStart = AnalyticsEvent(name: "login", properties: ["step": "start"])
+}
+
+extension WPAnalytics {
+    public static func track(_ event: AnalyticsEvent) {
+        WPAnalytics.trackString(event.name, withProperties: event.properties)
+    }
+}

--- a/WordPressShared/Core/Analytics/AnalyticsEvent.swift
+++ b/WordPressShared/Core/Analytics/AnalyticsEvent.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Declaring this class as final is a design choice to promote a simpler usage and implement events
 /// through parametrization of the `name` and `properties`.
 ///
-/// An example of a static event definition:
+/// An example of a static event definition (in the client App or Pod)::
 ///
 /// ~~~
 /// extension AnalyticsEvent {
@@ -12,7 +12,7 @@ import Foundation
 /// }
 /// ~~~
 ///
-/// An example of a dynamic / parametrized event definition:
+/// An example of a dynamic / parametrized event definition (in the client App or Pod):
 ///
 /// ~~~
 /// extension AnalyticsEvent {
@@ -31,7 +31,7 @@ import Foundation
 /// }
 /// ~~~
 ///
-/// Examples of tracking calls:
+/// Examples of tracking calls (in the client App or Pod):
 ///
 /// ~~~
 /// WPAnalytics.track(.login(step: .start))

--- a/WordPressShared/Core/Analytics/AnalyticsEvent.swift
+++ b/WordPressShared/Core/Analytics/AnalyticsEvent.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// This struct represents an analytics event.
 /// Declaring this class as final is a design choice to promote a simpler usage and implement events
-/// through parametrization of the `name` and `properties`.
+/// through parametrization of the `name` and `properties` properties.
 ///
-/// An example of a static event definition (in the client App or Pod)::
+/// An example of a static event definition (in the client App or Pod):
 ///
 /// ~~~
 /// extension AnalyticsEvent {


### PR DESCRIPTION
This PR proposes a new mechanism for analytics event tracking.

### Existing mechanisms:

There are two existing mechanisms for tracking analytics.  The older one requires that we add events to a huge list in the `WPShared` pod.  [See here](https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/a9d37616dda945514c75303a7f62db4887773aac/WordPressShared/Core/Analytics/WPAnalytics.h#L3).

The downsides are evident.  The most important one being it forced us to release a new version of the Shared pod each time an event was added, removed or changed.

The newer one was recently proposed by @leandroalonso.  It's much better than the old mechanism in that it allows us to define the events without having to release a new version of the shared pod.  [See here](https://github.com/wordpress-mobile/WordPress-iOS/blob/a48aea480053814aa2f10dcfbf67668f24c1cbb2/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift#L6).

While there's a very clear upside in this new mechanism, it still resulted in [a big list of event names within WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/a48aea480053814aa2f10dcfbf67668f24c1cbb2/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift#L6).

Additionally, the logic for defining the event properties is not bundled together with the events - it's still the [responsibility of the caller to define those properties](https://github.com/wordpress-mobile/WordPress-iOS/blob/a48aea480053814aa2f10dcfbf67668f24c1cbb2/WordPress/Classes/ViewRelated/System/Floating%20Create%20Button/FancyAlertViewController%2BCreateButtonAnnouncement.swift#L37).

### About this proposal:

This proposal promotes a new mechanism for events to be defined in a way that all of their construction logic is bundled in a single spot.  Events can also be declared and defined closer to where they belong.

This mechanism can co-exist with what we currently have, allowing us to incrementally migrate new events to it.

### Pros:

1. Events can now be declared and defined closer to where they're used (if we want to).  It's highly unlikely that events will be relevant across different flows, so having a huge list of events is not really an advantage.
2. The logic for building events can now be bundled in a single spot.
3. Strongly-typed and parametrised event properties on event construction (see the examples in the inline documentation).
4. Quite easy to use.

### Cons:

1. Yet a new mechanism for tracking events.  That said, this would be true for any architecture change we do.  Additionally, we can post about it to try and align people to start using it more.
2. Feel free to raise any other cons you can see.

### Example implementation:

As seen in this in-progress PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/335/files

Event declaration + definition:

```swift
extension AnalyticsEvent {
     enum LoginStep: String {
         case start
         case success
     }

     static func login(step: LoginStep) -> AnalyticsEvent {
         let properties = [
             "source": "default",
             "flow": "google_login",
             "step": step.rawValue,
         ]

         return AnalyticsEvent(name: "login", properties: properties)
     }
 }
```

Tracking the event:

```swift
WPAnalytics.track(.login(step: .start))
```

### Request for input:

I wasn't sure at first if to push this.  @bummytime convinced me to push the proposal as a PR and seek feedback on it.

It took me a while to reach this solution - the initial implementation wasn't as clean.  Right now my personal take is that it's quite cleaner and will help us make events easier to deal with and maintain.

@leandroalonso - Since you worked on this in the past.
@jleandroperez - Since you helped me think about this more.
@mindgraffiti, @ScoutHarris  - I'm planning to use this for the new events in unified Google login and all of our upcoming work if it's approved.
@aerych - Because I want your input too!

Also ping @frosty, fyi