### PR TITLE
Bump the pod version to 1.11.0-beta.1 and add comments

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.10.0-beta.3"
+  s.version       = "1.11.0-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Utility/CollectionType+Helpers.swift
+++ b/WordPressShared/Core/Utility/CollectionType+Helpers.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+
+// MARK: - Collection Type Helpers
+//
 extension BidirectionalCollection {
     public func lastIndex(where predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.Index? {
         if let idx = try reversed().firstIndex(where: predicate) {
@@ -10,8 +13,8 @@ extension BidirectionalCollection {
 }
 
 extension Collection {
-
     /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    ///
     public subscript (safe index: Index) -> Element? {
         return indices.contains(index) ? self[index] : nil
     }


### PR DESCRIPTION
This PR bumps the podspec to 1.11.0-beta.1 (instead of `1.10.0-beta.3`) so it can target WPiOS 15.6 and WPAuth 1.23.0

(I'll delete the incorrect 1.10.0-beta.3 tag after this PR is approved and released.)