### PR TITLE
Load system serif or Noto font at default size for style

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.11.0"
+  s.version       = "1.12.0-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -189,6 +189,28 @@ extension WPStyleGuide {
         return UIFont(descriptor: descriptorWithTraits, size: size)
     }
 
+    /// Creates a NotoSerif UIFont at the specified size.
+    ///
+    /// - Parameters:
+    ///     - size: The desired size.
+    ///
+    /// - Returns: The created font.
+    ///
+    @objc public class func fixedNotoFontWithSize(_ size: CGFloat) -> UIFont {
+        return fixedCustomNotoFontNamed("NotoSerif", withSize: size)
+    }
+
+    /// Creates a bold NotoSerif UIFont at the specified size.
+    ///
+    /// - Parameters:
+    ///     - size: The desired size.
+    ///
+    /// - Returns: The created font.
+    ///
+    @objc public class func fixedBoldNotoFontWithSize(_ size: CGFloat) -> UIFont {
+        return fixedCustomNotoFontNamed("NotoSerif-Bold", withSize: size)
+    }
+
     /// Creates a NotoSerif UIFont for the user current text size settings.
     ///
     /// - Parameters:
@@ -239,7 +261,7 @@ extension WPStyleGuide {
     ///     - fontName: the Noto font name (NotoSerif, NotoSerif-Bold, NotoSerif-Italic, NotoSerif-BoldItalic)
     ///     - style: The desired UIFontTextStyle.
     ///
-    /// - Returns: The created font point size.
+    /// - Returns: The created font.
     ///
     private class func customNotoFontNamed(_ fontName: String, forTextStyle style: UIFont.TextStyle, maximumPointSize: CGFloat = maxFontSize) -> UIFont {
         WPFontManager.loadNotoFontFamily()
@@ -248,6 +270,27 @@ extension WPStyleGuide {
         guard let font = UIFont(name: fontName, size: descriptor.pointSize) else {
             // If we can't get the Noto font for some reason we will default to the system font
             return fontForTextStyle(style)
+        }
+        return font
+    }
+
+    /// Creates a Noto UIFont at the specified size.
+    ///
+    /// - Parameters:
+    ///     - fontName: the Noto font name (NotoSerif, NotoSerif-Bold, NotoSerif-Italic, NotoSerif-BoldItalic)
+    ///     - size: The desired point size.
+    ///
+    /// - Returns: The created font.
+    ///
+    private class func fixedCustomNotoFontNamed(_ fontName: String, withSize size: CGFloat) -> UIFont {
+        WPFontManager.loadNotoFontFamily()
+        guard let font = UIFont(name: fontName, size: size) else {
+            // If we can't get the Noto font for some reason we will default to the system font
+            if fontName.contains("Bold") {
+                return UIFont.systemFont(ofSize: size, weight: .bold)
+            } else {
+                return UIFont.systemFont(ofSize: size)
+            }
         }
         return font
     }

--- a/WordPressShared/Core/Views/WPStyleGuide+SerifFonts.swift
+++ b/WordPressShared/Core/Views/WPStyleGuide+SerifFonts.swift
@@ -15,7 +15,27 @@ extension WPStyleGuide {
         return UIFontMetrics.default.scaledFont(for: UIFont(descriptor: fontDescriptor, size: 0.0))
     }
 
-    
+    // Returns the system serif font (New York) for iOS 13+ but defaults to noto for older os's, at the default size for the specified style
+    @objc public class func fixedSerifFontForTextStyle(_ style: UIFont.TextStyle,
+                                                       fontWeight weight: UIFont.Weight = .regular) -> UIFont {
+
+        let defaultContentSizeCategory = UITraitCollection(preferredContentSizeCategory: .large) // .large is the default
+        let fontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: defaultContentSizeCategory).pointSize
+
+        guard #available(iOS 13, *),
+            let fontDescriptor = UIFont.systemFont(ofSize: fontSize, weight: weight).fontDescriptor.withDesign(.serif)  else {
+                switch weight {
+                    case .bold, .semibold, .heavy, .black:
+                        return WPStyleGuide.fixedBoldNotoFontWithSize(fontSize)
+                default:
+                        return WPStyleGuide.fixedNotoFontWithSize(fontSize)
+                }
+        }
+
+        // Uses size from original font, so we don't want to override it here.
+        return UIFont(descriptor: fontDescriptor, size: 0.0)
+    }
+
     private class func notoFontForTextStyle(_ style: UIFont.TextStyle,
                                             fontWeight weight: UIFont.Weight = .regular) -> UIFont {
         var font: UIFont


### PR DESCRIPTION
This PR adds the ability to load a serif font (system-provided on iOS 13+, or Noto on older versions) at the default size for the specified font style. For example, the default size for the `headline` style is 17pt. This is to be used for navigation bar fonts, where we don't want the size to change based on the user's current dynamic type setting.

You can test using the [associated WPiOS PR here](https://github.com/wordpress-mobile/WordPress-iOS/pull/14803).