### PR TITLE
Adds post list duplicate action in analytics

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressShared"
-  s.version       = "1.13.0"
+  s.version       = "1.14.0-beta.1"
   s.summary       = "Shared components used in building the WordPress iOS apps and other library components."
 
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -324,6 +324,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatPostListTrashAction,
     WPAnalyticsStatPostListViewAction,
     WPAnalyticsStatPostListToggleButtonPressed,
+    WPAnalyticsStatPostListDuplicateAction,
     WPAnalyticsStatPostRevisionsListViewed,
     WPAnalyticsStatPostRevisionsDetailViewed,
     WPAnalyticsStatPostRevisionsDetailCancelled,


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/9662

**Related PR**
- `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/15460

Details for this change can be found at https://github.com/wordpress-mobile/WordPress-iOS/pull/15460.

Note: [I thought of using the new way of implementing this with using the WPAnalyticsEvent.swift
but that would make it inconsistent with the other post list button actions](https://github.com/wordpress-mobile/WordPress-iOS/pull/15460/files#r540387363). Not sure if this should be dropped in favour of the new way in any case.