### PR TITLE
Fix/16961 - Add missing event

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '1.16.1'
+  s.version       = '1.16.2-beta.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -385,6 +385,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatReaderArticleCommentsOpened,
     WPAnalyticsStatReaderArticleLiked,
     WPAnalyticsStatReaderArticleOpened,
+    WPAnalyticsStatReaderArticleRendered,
     WPAnalyticsStatReaderArticleReblogged,
     WPAnalyticsStatReaderArticleDetailReblogged,
     WPAnalyticsStatReaderArticleUnliked,


### PR DESCRIPTION
Part of [#17213](https://github.com/wordpress-mobile/WordPress-iOS/pull/17213)

This PR includes missing Reader tracking event `ReaderArticleRendered` that's triggered when the article finishes rendering the webview.