### PR TITLE
Improves the debouncer for ad-hoc callbacks.

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '1.16.1'
+  s.version       = '1.16.2-beta.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC

--- a/WordPressShared/Core/Utility/Debouncer.swift
+++ b/WordPressShared/Core/Utility/Debouncer.swift
@@ -34,7 +34,7 @@ public final class Debouncer {
         timer?.invalidate()
 
         if let newCallback = callback {
-            self.callback = callback
+            self.callback = newCallback
         }
 
         if immediate {

--- a/WordPressShared/Core/Utility/Debouncer.swift
+++ b/WordPressShared/Core/Utility/Debouncer.swift
@@ -6,13 +6,13 @@ import Foundation
 /// It also offers a mechanism to immediately trigger the scheduled call if necessary.
 ///
 public final class Debouncer {
-    private let callback: (() -> Void)
+    private var callback: (() -> Void)?
     private let delay: Double
     private var timer: Timer?
 
     // MARK: - Init & deinit
 
-    public init(delay: Double, callback: @escaping (() -> Void)) {
+    public init(delay: Double, callback: (() -> Void)? = nil) {
         self.delay = delay
         self.callback = callback
     }
@@ -20,7 +20,7 @@ public final class Debouncer {
     deinit {
         if let timer = timer, timer.fireDate >= Date() {
             timer.invalidate()
-            callback()
+            callback?()
         }
     }
 
@@ -30,8 +30,12 @@ public final class Debouncer {
         timer?.invalidate()
     }
 
-    public func call(immediate: Bool = false) {
+    public func call(immediate: Bool = false, callback: (() -> Void)? = nil) {
         timer?.invalidate()
+
+        if let newCallback = callback {
+            self.callback = callback
+        }
 
         if immediate {
             immediateCallback()
@@ -44,12 +48,12 @@ public final class Debouncer {
 
     private func immediateCallback() {
         timer = nil
-        callback()
+        callback?()
     }
 
     private func scheduleCallback() {
         timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] timer in
-            callback()
+            callback?()
         }
     }
 }

--- a/WordPressSharedTests/DebouncerTests.swift
+++ b/WordPressSharedTests/DebouncerTests.swift
@@ -60,4 +60,32 @@ class DebouncerTests: XCTestCase {
         
         wait(for: [debouncerHasRun], timeout: testTimeout)
     }
+
+    /// Tests that the debouncer works fine when used with an ad hoc callback.
+    ///
+    func testDebouncerWithAdHocCallback() {
+        let timerDelay = 0.5
+        let allowedError = 0.5
+        let minDelay = timerDelay * (1 - allowedError)
+        let maxDelay = timerDelay * (1 + allowedError)
+        let testTimeout = maxDelay + 0.01
+
+        let startDate = Date()
+        let debouncerHasRunAccurately = XCTestExpectation(description: "The debouncer should run within an accurate time range normally.")
+
+        let debouncer = Debouncer(delay: timerDelay)
+        debouncer.call() {
+            let actualDelay = Date().timeIntervalSince(startDate)
+
+            if actualDelay >= minDelay
+                && actualDelay <= maxDelay {
+
+                debouncerHasRunAccurately.fulfill()
+            } else {
+                XCTFail("Actual delay was: \(actualDelay))")
+            }
+        }
+
+        wait(for: [debouncerHasRunAccurately], timeout: testTimeout)
+    }
 }


### PR DESCRIPTION
Improves the debouncer for ad-hoc callbacks.

Basically we need the debouncer to support the modification of the callback, so that we can specify parameters that are unique to each scheduled call.

## Testing:

To test this, use the WordPress iOS PR.

1. Start the domain registration flow.
2. In the domain suggestions screen, start typing with the device keyboard.

Make sure the whole experience looks fine, and works fine.  The search should trigger after 0.5 seconds since the last keypress.

## Associated PRs:

WordPress iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17266