### PR TITLE
Add land in the editor event to analytics

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '1.17.0'
+  s.version       = '1.17.1-beta.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC

--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -172,6 +172,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatInstallJetpackRemoteStartManualFlow,
     WPAnalyticsStatInstallJetpackWebviewSelect,
     WPAnalyticsStatInstallJetpackWebviewFailed,
+    WPAnalyticsStatLandingEditorShown,
     WPAnalyticsStatLayoutPickerPreviewErrorShown,
     WPAnalyticsStatLayoutPickerPreviewLoaded,
     WPAnalyticsStatLayoutPickerPreviewLoading,


### PR DESCRIPTION
This PR adds an analytics event for landing in the editor. Please see the related PR for more details.

Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17429