### PR TITLE
Remove event for tapping the mode button on the design view

### DIFF
--- a/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -136,7 +136,6 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewViewed,
     WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewLoading,
     WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewLoaded,
-    WPAnalyticsStatEnhancedSiteCreationSiteDesignThumbnailModeButtonTapped,
     WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewModeButtonTapped,
     WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewModeChanged,
     WPAnalyticsStatEnhancedSiteCreationVerticalsViewed,


### PR DESCRIPTION
- Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/18455

This PR removes the `WPAnalyticsStatEnhancedSiteCreationSiteDesignThumbnailModeButtonTapped` event and will target the feature branch `feature/site-design-revamp`.