### PR TITLE
An experimental tool to check regular expressions at compile time

### DIFF
--- a/.buildkite/check_regex.sh
+++ b/.buildkite/check_regex.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+
+cd Tools
+
+echo '--- :swift: Build'
+swift build --product RegexChecker
+
+echo '--- :face_with_monocle: Check Regular Expressions'
+swift run --skip-build RegexChecker

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,6 +40,15 @@ steps:
     plugins: *common_plugins
 
   #################
+  # Check Regex
+  #################
+  - label: ":face_with_monocle: Check Regular Expressions"
+    key: "check-regex"
+    command: ".buildkite/check_regex.sh"
+    env: *common_env
+    plugins: *common_plugins
+
+  #################
   # Publish the Podspec (if we're building a tag)
   #################
   - label: "⬆️ Publish Podspec"
@@ -52,4 +61,5 @@ steps:
       - "test"
       - "validate"
       - "lint"
+      - "check-regex"
     if: build.tag != null

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ vendor/
 fastlane/test_output
 fastlane/README.md
 fastlane/report.xml
+
+.swiftpm

--- a/Tools/Package.resolved
+++ b/Tools/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "72d3da66b085c2299dd287c2be3b92b5ebd226de",
+        "version" : "0.50700.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "Tools",
+    platforms: [.macOS(.v12)],
+    products: [
+        .executable(
+            name: "RegexChecker",
+            targets: ["RegexChecker"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "0.50700.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "RegexChecker",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+            ]
+        )
+    ]
+)

--- a/Tools/Sources/RegexChecker/main.swift
+++ b/Tools/Sources/RegexChecker/main.swift
@@ -1,0 +1,95 @@
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxParser
+
+class RegexCheckerVisitor: SyntaxVisitor {
+    var declaration: VariableDeclSyntax?
+
+    var regexes = [String]()
+    var shouldFail: Bool = false
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        for piece in (node.leadingTrivia ?? []) {
+            if case let .lineComment(comment) = piece,
+               comment.hasPrefix("// CHECK-REGEX") {
+                self.declaration = node
+                break
+            }
+        }
+
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: VariableDeclSyntax) {
+        self.declaration = nil
+    }
+
+    override func visit(_ literal: StringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+        guard declaration != nil else {
+            return .visitChildren
+        }
+
+
+        for line in declaration!.description.split(separator: "\n") {
+            print("> \(line.trimmingCharacters(in: .whitespaces))")
+        }
+
+        guard literal.firstToken?.tokenKind == .rawStringDelimiter("#"),
+              literal.lastToken?.tokenKind == .rawStringDelimiter("#") else {
+            print("❌ Regex declaration must use raw string literal (i.e. #\"regex\"#).")
+            shouldFail = true
+            return .skipChildren
+        }
+
+        var regex = literal.description
+        regex.removeFirst()
+        regex.removeLast()
+
+        do {
+            let _ = try NSRegularExpression(pattern: regex)
+            print("✅ Valid regular expression.")
+        } catch {
+            print("❌ Not a regular expression.")
+            shouldFail = true
+        }
+
+        return .skipChildren
+    }
+
+    private func reportFailure(_ message: String) {
+        print("^ \(message)")
+
+        shouldFail = true
+    }
+}
+
+func checkRegexLiterals(directory: URL) throws -> Bool {
+    guard let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil) else {
+        fatalError("Can't enumerate directory at \(directory)")
+    }
+
+    var hasInvalidRegex = false
+
+    for case let file as URL in enumerator {
+        guard file.lastPathComponent.hasSuffix(".swift") else { continue }
+
+        let visitor = RegexCheckerVisitor()
+        let syntax = try SyntaxParser.parse(file)
+        visitor.walk(syntax)
+
+        if visitor.shouldFail {
+            hasInvalidRegex = true
+        }
+    }
+
+    return !hasInvalidRegex
+}
+
+func main() throws {
+    let thisFile = URL(fileURLWithPath: #filePath)
+    let sourcesDirectory = URL(string: "../../../WordPressShared", relativeTo: thisFile)!
+    let success = try checkRegexLiterals(directory: sourcesDirectory)
+    exit(success ? 0 : 1)
+}
+
+try main()

--- a/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/WordPressShared/Core/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -14,7 +14,8 @@ extension String {
     /// Strips Gutenberg galleries from strings.
     ///
     private func strippingGutenbergGalleries() -> String {
-        let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
+        // CHECK-REGEX
+        let pattern = #"(?s)<!--\swp:gallery?(.*?)wp:gallery\s-->"#
         
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }

--- a/WordPressShared/Core/Utility/String+StripShortcodes.swift
+++ b/WordPressShared/Core/Utility/String+StripShortcodes.swift
@@ -5,7 +5,8 @@ extension String {
     /// Creates a new string by stripping all shortcodes from this string.
     ///
     func strippingShortcodes() -> String {
-        let pattern = "\\[[^\\]]+\\]"
+        // CHECK-REGEX
+        let pattern = #"\[[^\]]+\]"#
         
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }


### PR DESCRIPTION
This is a random idea popped into my head today, not sure if it's worth pursuing, but I had fun learning swift-syntax and swift AST. We can move this tool into the bash-cache plugin or some other places, if we find this tool useful. 😸 

The idea is use a special inline comment `// CHECK-REGEX` to check if the following string constant declaration is a valid regex. Kinda like Swift 5.7's Regex constant compile time check, except we don't have to wait for 2 or 3 years (Swift's Regex is only available on iOS 16).

Here is an example:

```swift
// CHECK-REGEX
let pattern = #"\[[^\]]+\]"#
```

One requirement of this check is the string constant needs to be a raw string literal (without string interpolation), otherwise we can't know the regex at compile time.

The implementation is quite simple. Iterate through all the Swift files in given directory, find a declaration that has this special inline comment, extract the regex from the expression, and finally check the regex by creating a `NSRegularExpression` instance with it.

Since this is an experimental tool, I didn't handle any edge cases (i.e. the inline comment is used on a non-string declaration) and the error reporting probably can be improved too (i.e. include file and line number in the error message).

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
