### PR TITLE
Use Xcode 14.1 (RC 1) in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   plugins: &common_plugins
   - &bash_cache automattic/bash-cache#2.10.0
   env: &common_env
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-14.1-rc.1
 
 # This is the default pipeline – it will build and test the pod
 steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,10 +5,6 @@ default_platform(:ios)
 platform :ios do
   desc 'Builds the project and runs tests'
   lane :test do
-    xcodebuild(
-      scheme: 'WordPressShared',
-      xcargs: '-resolvePackageDependencies'
-    )
     run_tests(
       package_path: '.',
       scheme: 'WordPressShared',


### PR DESCRIPTION
This is mostly to see if the tooling issue seen in #321 disappears on a newer Xcode version.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
