### PR TITLE
Bump version to 2.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,25 @@ _None._
 
 ### New Features
 
-- Add Swift Package Manager support [#321]
-- Remove CocoaLumberjack. The app needs to provide a `WordPressLoggingDelegate` implementation [#325]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## [2.0.0-beta.1](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.1)
+
+### Breaking Changes
+
+- Remove CocoaLumberjack. The app needs to provide a `WordPressLoggingDelegate` implementation [#325]
+
+### New Features
+
+- Add Swift Package Manager support [#321]
 
 ### Internal Changes
 

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '1.18.0'
+  s.version       = '2.0.0-beta.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
A major version bump as an API ([`WPSharedSetLoggingLevel`](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/325/files#diff-4a9829f40d62f2b4bfceb3192ed4e5788414c9c7f4f29043546a6c06819b76ce)) was removed.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
