### PR TITLE
Fix cocoapods generate duplicate UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _None._
 
 ### Bug Fixes
 
-- Fix an issue where 'pod install' produces a 'duplicate UUID' warning.
+- Fix an issue where 'pod install' produces a 'duplicate UUID' warning. [#327]
 
 ## [2.0.0-beta.1](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## [2.0.0-beta.2](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.2)
+
+### Bug Fixes
+
+- Fix an issue where 'pod install' produces a 'duplicate UUID' warning.
+
 ## [2.0.0-beta.1](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.1)
 
 ### Breaking Changes

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -26,6 +26,7 @@ Pod::Spec.new do |s|
   s.source_files  = ['Sources/WordPressShared/**/*.swift'] \
     + FileList['Sources/WordPressSharedObjC/**/*.{h,m}'].exclude('Sources/WordPressSharedObjC/include')
   s.public_header_files = 'Sources/WordPressSharedObjC/include', 'Sources/WordPressSharedObjC/WordPressShared.h'
+  s.private_header_files = 'Sources/WordPressSharedObjC/Private/*.h'
   s.resource_bundles = {
     WordPressShared: [
       'Sources/WordPressShared/Resources/*.{ttf,otf,json}',

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
+require 'rake'
 
-# Helper to lookup ObjC source files
-module Lookup
-  def self.objc_files
-    directory = Pathname.new('Sources/WordPressSharedObjC')
-    include_dir = directory.join('include')
-    public_header_files = include_dir.glob('*.h')
-                                     .map { |link| link.realpath.relative_path_from(Dir.pwd) }
-    source_files = directory.glob('**/*.{h,m}').reject { |file| (file <=> include_dir) == 1 }
-    {
-      source_files: source_files.map(&:to_s),
-      public_header_files: public_header_files.map(&:to_s)
-    }
-  end
-end
+# rubocop:disable Metrics/BlockLength
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
@@ -36,8 +23,9 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.source        = { git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', tag: s.version.to_s }
-  s.source_files  = ['Sources/WordPressShared/**/*.swift'] + Lookup.objc_files[:source_files]
-  s.public_header_files = ['Sources/WordPressSharedObjC/WordPressShared.h'] + Lookup.objc_files[:public_header_files]
+  s.source_files  = ['Sources/WordPressShared/**/*.swift'] \
+    + FileList['Sources/WordPressSharedObjC/**/*.{h,m}'].exclude('Sources/WordPressSharedObjC/include')
+  s.public_header_files = 'Sources/WordPressSharedObjC/include', 'Sources/WordPressSharedObjC/WordPressShared.h'
   s.resource_bundles = {
     WordPressShared: [
       'Sources/WordPressShared/Resources/*.{ttf,otf,json}',

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -2,9 +2,24 @@
 
 # rubocop:disable Metrics/BlockLength
 
+# Helper to lookup ObjC source files
+module Lookup
+  def self.objc_files
+    directory = Pathname.new('Sources/WordPressSharedObjC')
+    include_dir = directory.join('include')
+    public_header_files = include_dir.glob('*.h')
+                                     .map { |link| link.realpath.relative_path_from(Dir.pwd) }
+    source_files = directory.glob('**/*.{h,m}').reject { |file| (file <=> include_dir) == 1 }
+    {
+      source_files: source_files.map(&:to_s),
+      public_header_files: public_header_files.map(&:to_s)
+    }
+  end
+end
+
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.0.0-beta.1'
+  s.version       = '2.0.0-beta.2'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC
@@ -21,9 +36,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.source        = { git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', tag: s.version.to_s }
-  s.source_files  = 'Sources/WordPressShared/**/*.swift', 'Sources/WordPressSharedObjC/**/*.{h,m}'
-  s.public_header_files = 'Sources/WordPressSharedObjC/include', 'Sources/WordPressSharedObjC/WordPressShared.h'
-  s.private_header_files = 'Sources/WordPressSharedObjC/Private/*.h'
+  s.source_files  = ['Sources/WordPressShared/**/*.swift'] + Lookup.objc_files[:source_files]
+  s.public_header_files = ['Sources/WordPressSharedObjC/WordPressShared.h'] + Lookup.objc_files[:public_header_files]
   s.resource_bundles = {
     WordPressShared: [
       'Sources/WordPressShared/Resources/*.{ttf,otf,json}',


### PR DESCRIPTION
This PR resolves the "duplicated UUIDs" warning reported by `pod install` when using the `2.0.0-beta.1` podspec.

The Objective-C target has an include directory (which is SPM's convention) which contains symbolic links to the real header files. All those header files are part of the pods' `source_files`, which leads the generated Xcode target contains duplicated header files–one is the symlink file and the other is the real file. Hence, CocoaPods reports the "duplicated UUIDs" warning since the UUID is generated from file name.

The fix is simply excluding the `include` directory, which is meant to be SPM-only anyway, from podspec's `source_files`.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
