### PR TITLE
Fix an occasional crash caused by performSelector:withObject:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Fix an occasional crash caused by `performSelector:withObject:`
+- Fix an occasional crash caused by `performSelector:withObject:` [#328]
 
 ## [2.0.0-beta.2](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Fix an occasional crash caused by `performSelector:withObject:`
 
 ## [2.0.0-beta.2](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.2)
 

--- a/Sources/WordPressSharedObjC/Logging/WPSharedLogging.m
+++ b/Sources/WordPressSharedObjC/Logging/WPSharedLogging.m
@@ -23,7 +23,9 @@ void WPSharedSetLoggingDelegate(id<WordPressLoggingDelegate> _Nullable logger)
             NSLog(@"[WordPress-Shared] Warning: %@ does not implement " #logFunc, logger); \
             return; \
         } \
-        [logger performSelector:@selector(logFunc) withObject:[[NSString alloc] initWithFormat:str arguments:args]]; \
+        /* Originally `performSelector:withObject:` was used to call the logging function, but for unknown reason */ \
+        /* it causes a crash on `objc_retain`. So I have to switch to this strange "syntax" to call the logging function directly. */ \
+        [logger logFunc [[NSString alloc] initWithFormat:str arguments:args]]; \
     })
 
 #define WPSharedLog(logFunc) \


### PR DESCRIPTION
Not sure why this method would cause a crash on `objc_retain`. Also this crash only happens on CI, not on my Mac.

Two out of five jobs on this repo's trunk branch failed because of this issue. Whereas in a WordPressKit PR, this crash happens constantly.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
