### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,9 @@ _None._
 
 ### Internal Changes
 
-- Fix an occasional crash caused by `performSelector:withObject:` [#328]
+_None._
 
-## [2.0.0-beta.2](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.2)
-
-### Bug Fixes
-
-- Fix an issue where 'pod install' produces a 'duplicate UUID' warning. [#327]
-
-## [2.0.0-beta.1](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0-beta.1)
+## [2.0.0](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.0)
 
 ### Breaking Changes
 
@@ -64,8 +58,13 @@ _None._
 
 - Add Swift Package Manager support [#321]
 
+### Bug Fixes
+
+- Fix an issue where 'pod install' produces a 'duplicate UUID' warning. [#327]
+
 ### Internal Changes
 
 - Add this changelog entry about changelog itself [#317]
 - Remove FormatterKit [#320]
 - Move away from Specta, use Quick instead [#319]
+- Fix an occasional crash caused by `performSelector:withObject:` [#328]

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -6,7 +6,7 @@ require 'rake'
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.0.0-beta.2'
+  s.version       = '2.0.0'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
As part of the release, I've added `2.0.0` section to `CHANGELOG` and combined the current unreleased section as well as the beta release notes under it. Note that, the format change for `CHANGELOG` was discussed in https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/327.