### PR TITLE
Fix resource bundle for WordPressShared when installed from CocoaPods

### DIFF
--- a/Sources/WordPressSharedObjC/Utility/WPFontManager.m
+++ b/Sources/WordPressSharedObjC/Utility/WPFontManager.m
@@ -108,12 +108,7 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
 
 + (void)loadFontResourceNamed:(NSString *)name withExtension:(NSString *)extension
 {
-#if SWIFT_PACKAGE
-    NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
-#else
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-#endif
-    NSURL *url = [bundle URLForResource:name withExtension:extension];
+    NSURL *url = [[self resourceBundle] URLForResource:name withExtension:extension];
 
     CFErrorRef error;
     if (!CTFontManagerRegisterFontsForURL((CFURLRef)url, kCTFontManagerScopeProcess, &error)) {
@@ -123,6 +118,22 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
     }
 
     return;
+}
+
++ (NSBundle *)resourceBundle {
+#if SWIFT_PACKAGE
+    return SWIFTPM_MODULE_BUNDLE;
+#else
+    // When installed via CocoaPods, the resources will be bundled under `WordPressShared.bundle`.
+    // This follows the implementation from `NSBundle+WordPressShared`.
+    NSBundle *defaultBundle = [NSBundle bundleForClass:[self class]];
+    NSURL *sharedBundleURL = [defaultBundle.bundleURL URLByAppendingPathComponent:@"WordPressShared.bundle"];
+    NSBundle *sharedBundle = [NSBundle bundleWithURL:sharedBundleURL];
+    if (sharedBundle) {
+        return sharedBundle;
+    }
+    return defaultBundle;
+#endif
 }
 
 @end

--- a/Sources/WordPressSharedObjC/Utility/WPFontManager.m
+++ b/Sources/WordPressSharedObjC/Utility/WPFontManager.m
@@ -127,7 +127,7 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
     // When installed via CocoaPods, the resources will be bundled under `WordPressShared.bundle`.
     // This follows the implementation from `NSBundle+WordPressShared`.
     NSBundle *defaultBundle = [NSBundle bundleForClass:[self class]];
-    NSURL *sharedBundleURL = [defaultBundle.bundleURL URLByAppendingPathComponent:@"WordPressShared.bundle"];
+    NSURL *sharedBundleURL = [defaultBundle.resourceURL URLByAppendingPathComponent:@"WordPressShared.bundle"];
     NSBundle *sharedBundle = [NSBundle bundleWithURL:sharedBundleURL];
     if (sharedBundle) {
         return sharedBundle;

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.0.0'
+  s.version       = '2.0.1-beta.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/19877, p5T066-3ND-p2#comment-14170, p5T066-3ND-p2#comment-14172

This fixes an issue where the WordPressShared no longer loads the Noto font family correctly, resulting in the app content (editor, comment threads) being displayed with the default font from HTML.

In `1.18.0`, `WPFontManager` loads the bundle was loaded through this method:

https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/3ed6530c1cb7a56c632afad808b279074692d0a3/WordPressShared/Core/Utility/WPFontManager.m#L113

However, the method has since been [moved to the Swift part](https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/trunk/Sources/WordPressShared/Utility/NSBundle%2BWordPressShared.swift) in `WordPressShared`, and is inaccessible from `WPFontManager` because the font manager is inside `WordPressSharedObjC` which is depended upon by `WordPressShared`, but not the other way around. CMIIW.

When debugging the app, the fonts are located in `WordPress.app/WordPressShared.bundle` since the `WordPressShared` is still included through CocoaPods. Following the solution from `NSBundle+WordPressShared.swift`, this attempts to add the `WordPressShared.bundle` to the bundle path when loading the font.

## To Test

Refer to https://github.com/wordpress-mobile/WordPress-iOS/pull/19898.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.