### PR TITLE
Bump version from 2.0.1-beta.1 to 2.0.1 stable

### DIFF
--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.0.1-beta.1'
+  s.version       = '2.0.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 21.6 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
