### PR TITLE
Add a `WordPressLoggingDelegate` implementation that logs to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `ConsoleLogger`, a `WordPressLoggingDelegate` implementation that can be used during development and debugging [#335]
 
 ### Bug Fixes
 

--- a/Sources/WordPressShared/Utility/ConsoleLogger.swift
+++ b/Sources/WordPressShared/Utility/ConsoleLogger.swift
@@ -1,0 +1,24 @@
+/// A `WordPressLoggingDelegate` implementation that logs to the Xcode console via `print`.
+/// Useful for development or debugging. Not recommended in release builds.
+public class ConsoleLogger: NSObject, WordPressLoggingDelegate {
+
+    public func logError(_ str: String) {
+        print("❌ – Error: \(str)")
+    }
+
+    public func logWarning(_ str: String) {
+        print("⚠️ – Warning: \(str)")
+    }
+
+    public func logInfo(_ str: String) {
+        print("ℹ️ – Info: \(str)")
+    }
+
+    public func logDebug(_ str: String) {
+        print("🔎 – Debug: \(str)")
+    }
+
+    public func logVerbose(_ str: String) {
+        print("📃 – Verbose: \(str)")
+    }
+}

--- a/Sources/WordPressShared/Utility/ConsoleLogger.swift
+++ b/Sources/WordPressShared/Utility/ConsoleLogger.swift
@@ -3,22 +3,22 @@
 public class ConsoleLogger: NSObject, WordPressLoggingDelegate {
 
     public func logError(_ str: String) {
-        print("❌ – Error: \(str)")
+        NSLog("❌ – Error: \(str)")
     }
 
     public func logWarning(_ str: String) {
-        print("⚠️ – Warning: \(str)")
+        NSLog("⚠️ – Warning: \(str)")
     }
 
     public func logInfo(_ str: String) {
-        print("ℹ️ – Info: \(str)")
+        NSLog("ℹ️ – Info: \(str)")
     }
 
     public func logDebug(_ str: String) {
-        print("🔎 – Debug: \(str)")
+        NSLog("🔎 – Debug: \(str)")
     }
 
     public func logVerbose(_ str: String) {
-        print("📃 – Verbose: \(str)")
+        NSLog("📃 – Verbose: \(str)")
     }
 }


### PR DESCRIPTION
When working on the WordPress Authenticator  demo app for Google SignIn testing, I got a message about `WordPressLoggingDelegate` not being implemented. I put together this simpler implementation to `print`s to the console to satisfy the requirement. I think it might be useful during development or debugging and worth shipping together with the `protocol`.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
