### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,23 @@ _None._
 
 ### New Features
 
-- Add `ConsoleLogger`, a `WordPressLoggingDelegate` implementation that can be used during development and debugging [#335]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## [2.1.0](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.1.0)
+
+### New Features
+
+- Add `ConsoleLogger`, a `WordPressLoggingDelegate` implementation that can be used during development and debugging [#335]
+
+## [2.0.1](https://github.com/wordpress-mobile/WordPress-iOS-Shared/releases/tag/2.0.1)
 
 ### Internal Changes
 

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.0.1'
+  s.version       = '2.1.0'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
**TL;DR** I'd like to ship a new release of this library. Normally, I'd just ship it, but I'd like to run it past you because we're in a phase of transition in how we manage internal Apple libraries and I don't want to generate confusion.

So far and in the context of release management I haven't been requesting reviews in PRs for library releases because it seems to me like unnecessary [ceremony](https://giolodi.com/2022/10/process-friction-vocabulary/). The only code that's reviewed is the version bump, and while it's true that there is room for error in that, too, in the context of libraries meant for internal shipping a build with the wrong version ever once in a while is worth not having to wait for a review every time. _IMHO_.

But this is a release outside the usual apps release cycle and in a time of migration from the model of using betas to ship changes to using `trunk` during development. So, I'm asking for a review because I want to run past you the idea of making a new release outside the usual cycle, that is, without a code freeze starting at the same time.

The reason I want to do a new release is to use `ConsoleLogger`, #335, in the demo app for WordPress Authenticator. I am already using `ConsoleLogger` via `trunk` in [there](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/commit/aa664d286afea3e0f432e729e1155dc112e24e4a) and verified it works.

I didn't opt for a beta because we are actively trying to move away from them in the client apps.

What do you think? Is it appropriate to ship a new build at this time to distribute a new feature to a downstream dependency?

I think it is. Client apps can point to `trunk` during development, but client libraries should always point to shipped versions of their dependencies.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
