### PR TITLE
Point `bash-cache` plugin to new `a8c-ci-toolkit` location

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#2.13.0
   env: &common_env
     IMAGE_ID: xcode-14
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#2.10.0
+  - &bash_cache automattic/a8c-ci-toolkit#2.10.0
   env: &common_env
     IMAGE_ID: xcode-14
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/a8c-ci-toolkit#2.10.0
+  - &bash_cache automattic/a8c-ci-toolkit#2.13.0
   env: &common_env
     IMAGE_ID: xcode-14
 


### PR DESCRIPTION
We decided to rename the plugin to `a8c-ci-toolkit` to better reflect the commands it offers.

While I was at it, I upgraded it to the latest version, 2.13.0.

I used the following command, which was a bit of overkill given there's only one instance, but it'll come handy in other repos. 

```
find . -type f \( -name "*.yml" \) -exec sed -i '' 's/automattic\/bash-cache/automattic\/a8c-ci-toolkit/g' {} +
```

The command could also be improved to update the version number as well. 

If CI is green, then the plugin was fetched correctly.

Internal ref: paaHJt-4z0-p2

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – IMHO, N.A.