### PR TITLE
Strip Gutenberg VideoPress block for excerpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Strip Gutenberg VideoPress block for excerpt [#339]
 
 ### Bug Fixes
 

--- a/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -8,13 +8,21 @@ extension String {
     /// This method is the main entry point to generate excerpts for Gutenberg content.
     ///
     public func strippingGutenbergContentForExcerpt() -> String {
-        return strippingGutenbergGalleries()
+        return strippingGutenbergGalleries().strippingGutenbergVideoPress()
     }
     
     /// Strips Gutenberg galleries from strings.
     ///
     private func strippingGutenbergGalleries() -> String {
         let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
+        
+        return removingMatches(pattern: pattern, options: .caseInsensitive)
+    }
+    
+    /// Strips Gutenberg VideoPress block.
+    ///
+    private func strippingGutenbergVideoPress() -> String {
+        let pattern = "(?s)\n?<!--\\swp:videopress/video?(.*?)wp:videopress/video\\s-->"
         
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }

--- a/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -4,26 +4,26 @@ import Foundation
 /// shown when generating post excerpts.
 ///
 extension String {
-    
+
     /// This method is the main entry point to generate excerpts for Gutenberg content.
     ///
     public func strippingGutenbergContentForExcerpt() -> String {
         return strippingGutenbergGalleries().strippingGutenbergVideoPress()
     }
-    
+
     /// Strips Gutenberg galleries from strings.
     ///
     private func strippingGutenbergGalleries() -> String {
         let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
-        
+
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
-    
+
     /// Strips Gutenberg VideoPress block.
     ///
     private func strippingGutenbergVideoPress() -> String {
         let pattern = "(?s)\n?<!--\\swp:videopress/video?(.*?)wp:videopress/video\\s-->"
-        
+
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
 }

--- a/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -2,40 +2,40 @@ import XCTest
 @testable import WordPressShared
 
 class StringStripGutenbergContentForExcerptTests: XCTestCase {
-    
+
     func testStrippingGutenbergContentForExcerpt() {
         let content = "<p>Some Content</p>"
         let expectedSummary = "<p>Some Content</p>"
-        
+
         let summary = content.strippingGutenbergContentForExcerpt()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testStrippingGutenbergContentForExcerptWithGallery() {
         let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
         let expectedSummary = "<p>Some Content</p>"
-        
+
         let summary = content.strippingGutenbergContentForExcerpt()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testStrippingGutenbergContentForExcerptWithGallery2() {
         let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
         let expectedSummary = "<p>Before</p>\n<p>After</p>"
-        
+
         let summary = content.strippingGutenbergContentForExcerpt()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testStrippingGutenbergContentForExcerptWithVideoPress() {
         let content = "<p>Before</p>\n<!-- wp:videopress/video {\"title\":\"demo\",\"description\":\"\",\"id\":5297,\"guid\":\"AbCDe\",\"videoRatio\":56.333333333333336,\"privacySetting\":2,\"allowDownload\":false,\"rating\":\"G\",\"isPrivate\":true,\"duration\":1673} -->\n<figure class=\"wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player\"><div class=\"jetpack-videopress-player__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:videopress/video -->\n<p>After</p>"
         let expectedSummary = "<p>Before</p>\n<p>After</p>"
-        
+
         let summary = content.strippingGutenbergContentForExcerpt()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
 }

--- a/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -29,4 +29,13 @@ class StringStripGutenbergContentForExcerptTests: XCTestCase {
         
         XCTAssertEqual(summary, expectedSummary)
     }
+    
+    func testStrippingGutenbergContentForExcerptWithVideoPress() {
+        let content = "<p>Before</p>\n<!-- wp:videopress/video {\"title\":\"demo\",\"description\":\"\",\"id\":5297,\"guid\":\"AbCDe\",\"videoRatio\":56.333333333333336,\"privacySetting\":2,\"allowDownload\":false,\"rating\":\"G\",\"isPrivate\":true,\"duration\":1673} -->\n<figure class=\"wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player\"><div class=\"jetpack-videopress-player__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:videopress/video -->\n<p>After</p>"
+        let expectedSummary = "<p>Before</p>\n<p>After</p>"
+        
+        let summary = content.strippingGutenbergContentForExcerpt()
+        
+        XCTAssertEqual(summary, expectedSummary)
+    }
 }


### PR DESCRIPTION
This PR strips the VideoPress block tag when generating the excerpt for Gutenberg content.

| Content | Before | After |
|--------|--------|--------|
| <img src=https://user-images.githubusercontent.com/14905380/231423843-a9920477-9f19-4bf1-9e1b-3873a388cf4c.png> | <img src=https://user-images.githubusercontent.com/14905380/231423379-a630740b-a6a7-4fd1-8c5c-80fb76c5bdaf.png> | <img src=https://user-images.githubusercontent.com/14905380/231423536-8e4ef27c-80f8-4ec4-b839-3fe23fdb0b3a.png> | 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
