### PR TITLE
feat: Add editor upload paused event

### DIFF
--- a/Sources/WordPressSharedObjC/include/WPAnalytics.h
+++ b/Sources/WordPressSharedObjC/include/WPAnalytics.h
@@ -126,6 +126,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatEditorToggledOn,
     WPAnalyticsStatEditorUpdatedPost,
     WPAnalyticsStatEditorUploadMediaFailed,
+    WPAnalyticsStatEditorUploadMediaPaused,
     WPAnalyticsStatEditorUploadMediaRetried,
     WPAnalyticsStatEnhancedSiteCreationAccessed,
     WPAnalyticsStatEnhancedSiteCreationSegmentsViewed,


### PR DESCRIPTION
## Related

- https://github.com/wordpress-mobile/WordPress-iOS/pull/22376

## Description

The paused event represents media uploads that are "paused" due to the lack of an network connection.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
