### PR TITLE
Merge 2.3.0 stable release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#2.13.0
+    - automattic/a8c-ci-toolkit#3.0.1
   env: &common_env
     IMAGE_ID: xcode-15.0.1
 
@@ -12,11 +12,10 @@ steps:
   ########################
   - label: "🔬 Validate Swift Package"
     key: "test"
-    command: |
-      validate_swift_package
+    command: validate_swift_package
     env: *common_env
     plugins: *common_plugins
-    artifact_paths: 
+    artifact_paths:
       - .build/logs/*.log
       - .build/derived-data/Logs/**/*.xcactivitylog
 
@@ -25,13 +24,7 @@ steps:
   #################
   - label: "🔬 Validate Podspec"
     key: "validate"
-    command: |
-      # validate_podspec
-      echo '+++ ⚠️ validate_podspec was bypassed ⚠️'
-      # post a message in the logs
-      cat .buildkite/validate_podspec_annotation.md
-      # and also as an annotation
-      cat .buildkite/validate_podspec_annotation.md | buildkite-agent annotate --style 'warning'
+    command: validate_podspec --patch-cocoapods
     env: *common_env
     plugins: *common_plugins
     artifact_paths: ".build/logs/*.log"
@@ -41,8 +34,7 @@ steps:
   #################
   - label: "🧹 Lint"
     key: "lint"
-    command: |
-      lint_pod
+    command: lint_pod
     env: *common_env
     plugins: *common_plugins
 
@@ -51,8 +43,7 @@ steps:
   #################
   - label: "⬆️ Publish Podspec"
     key: "publish"
-    command: |
-      .buildkite/publish-pod.sh
+    command: .buildkite/publish-pod.sh
     env: *common_env
     plugins: *common_plugins
     depends_on:

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -8,10 +8,10 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"
-publish_pod $PODSPEC_PATH
+publish_pod --patch-cocoapods $PODSPEC_PATH
 
 echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
-publish_private_pod $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
+publish_private_pod --patch-cocoapods $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
 
 echo "--- :slack: Notifying Slack"
-slack_notify_pod_published $PODSPEC_PATH $SLACK_WEBHOOK
+slack_notify_pod_published $PODSPEC_PATH "$SLACK_WEBHOOK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 2.3.0
+
+### New Features
+
+- Add editor upload paused event [#343]
+
 ## 2.2.0
 
 ### New Features

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.2.0'
+  s.version       = '2.3.0'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION


This version bump PR is part of the code freeze workflow for WordPress iOS [24.1](https://github.com/wordpress-mobile/WordPress-iOS/milestone/267) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.