### PR TITLE
Fix SwiftLint violations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
             ],
             resources: [.process("Resources")],
             plugins: [
-              .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .testTarget(
@@ -41,7 +41,7 @@ let package = Package(
                 "OHHTTPStubs",
             ],
             plugins: [
-              .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .testTarget(
@@ -55,7 +55,7 @@ let package = Package(
             ],
             resources: [.process("Resources")],
             plugins: [
-              .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
     ]

--- a/Sources/WordPressShared/Utility/Debouncer.swift
+++ b/Sources/WordPressShared/Utility/Debouncer.swift
@@ -25,7 +25,7 @@ public final class Debouncer {
     }
 
     // MARK: - Debounce Request
-    
+
     public func cancel() {
         timer?.invalidate()
     }

--- a/Sources/WordPressShared/Utility/EmailTypoChecker.swift
+++ b/Sources/WordPressShared/Utility/EmailTypoChecker.swift
@@ -40,7 +40,7 @@ private let knownDomains = Set([
 
     /* Domains used in Mexico */
     "hotmail.com", "gmail.com", "yahoo.com.mx", "live.com.mx", "yahoo.com", "hotmail.es", "live.com", "hotmail.com.mx", "prodigy.net.mx", "msn.com"
-    ])
+])
 
 /// Provides suggestions to fix common typos on email addresses.
 ///

--- a/Sources/WordPressShared/Utility/Languages.swift
+++ b/Sources/WordPressShared/Utility/Languages.swift
@@ -137,8 +137,8 @@ public class WordPressComLanguageDatabase: NSObject {
         ///
         init?(dict: [String: Any]) {
             guard let unwrappedId = (dict[Keys.identifier] as? NSNumber)?.intValue,
-                        let unwrappedSlug = dict[Keys.slug] as? String,
-                        let unwrappedName = dict[Keys.name] as? String else {
+                  let unwrappedSlug = dict[Keys.slug] as? String,
+                  let unwrappedName = dict[Keys.name] as? String else {
                 id = Int.min
                 name = String()
                 slug = String()
@@ -153,7 +153,7 @@ public class WordPressComLanguageDatabase: NSObject {
 
         /// Given an array of raw languages, will return a parsed array.
         ///
-        public static func fromArray(_ array: [[String:Any]] ) -> [Language] {
+        public static func fromArray(_ array: [[String: Any]] ) -> [Language] {
             return array.compactMap {
                 return Language(dict: $0)
             }

--- a/Sources/WordPressShared/Utility/NSBundle+WordPressShared.swift
+++ b/Sources/WordPressShared/Utility/NSBundle+WordPressShared.swift
@@ -11,17 +11,17 @@ extension Bundle {
     /// otherwise it will be the framework bundle.
     ///
     @objc public class var wordPressSharedBundle: Bundle {
-#if SWIFT_PACKAGE
+        #if SWIFT_PACKAGE
         return Bundle.module
-#else
+        #else
         let defaultBundle = Bundle(for: BundleFinder.self)
         // If installed with CocoaPods, resources will be in WordPressShared.bundle
         if let bundleURL = defaultBundle.resourceURL,
-            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPressShared.bundle")) {
+           let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPressShared.bundle")) {
             return resourceBundle
         }
         // Otherwise, the default bundle is used for resources
         return defaultBundle
-#endif
+        #endif
     }
 }

--- a/Sources/WordPressShared/Utility/NSString+Summary.swift
+++ b/Sources/WordPressShared/Utility/NSString+Summary.swift
@@ -4,9 +4,9 @@ import Foundation
 /// and convert HTML into plain text.
 ///
 extension NSString {
-    
+
     static let PostDerivedSummaryLength = 150
-    
+
     /// Create a summary for the post based on the post's content.
     ///
     /// - Returns: A summary for the post.
@@ -14,14 +14,14 @@ extension NSString {
     @objc
     public func summarized() -> String {
         let characterSet = CharacterSet(charactersIn: "\n")
-        
+
         return (self as String).strippingGutenbergContentForExcerpt()
             .strippingShortcodes()
             .makePlainText()
             .trimmingCharacters(in: characterSet)
             .ellipsizing(withMaxLength: NSString.PostDerivedSummaryLength, preserveWords: true)
     }
-    
+
     /// Converts HTML content into plain text by stripping HTML tags and decodinig XML chars.
     /// Transforms the specified string to plain text.  HTML markup is removed and HTML entities are decoded.
     ///
@@ -30,7 +30,7 @@ extension NSString {
     @objc
     public func makePlainText() -> String {
         let characterSet = NSCharacterSet.whitespacesAndNewlines
-        
+
         return strippingHTML()
             .decodingXMLCharacters()
             .trimmingCharacters(in: characterSet)

--- a/Sources/WordPressShared/Utility/RichContentFormatter.swift
+++ b/Sources/WordPressShared/Utility/RichContentFormatter.swift
@@ -81,14 +81,14 @@ import WordPressSharedObjC
         var content = string
 
         content = RegEx.styleTags.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: "")
+                                                           options: .reportCompletion,
+                                                           range: NSRange(location: 0, length: content.count),
+                                                           withTemplate: "")
 
         content = RegEx.scriptTags.stringByReplacingMatches(in: content,
-                                                                    options: .reportCompletion,
-                                                                    range: NSRange(location: 0, length: content.count),
-                                                                    withTemplate: "")
+                                                            options: .reportCompletion,
+                                                            range: NSRange(location: 0, length: content.count),
+                                                            withTemplate: "")
 
         content = RegEx.gutenbergComments.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
@@ -114,27 +114,27 @@ import WordPressSharedObjC
         let openPTag = "<p>"
         let closePTag = "</p>"
 
-         // Convert div tags to p tags
+        // Convert div tags to p tags
         content = RegEx.divTagsStart.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: openPTag)
+                                                              options: .reportCompletion,
+                                                              range: NSRange(location: 0, length: content.count),
+                                                              withTemplate: openPTag)
 
         content = RegEx.divTagsEnd.stringByReplacingMatches(in: content,
-                                                                    options: .reportCompletion,
-                                                                    range: NSRange(location: 0, length: content.count),
-                                                                    withTemplate: closePTag)
+                                                            options: .reportCompletion,
+                                                            range: NSRange(location: 0, length: content.count),
+                                                            withTemplate: closePTag)
 
         // Remove duplicate/redundant p tags.
         content = RegEx.pTagsStart.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: openPTag)
+                                                            options: .reportCompletion,
+                                                            range: NSRange(location: 0, length: content.count),
+                                                            withTemplate: openPTag)
 
         content = RegEx.pTagsEnd.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: closePTag)
+                                                          options: .reportCompletion,
+                                                          range: NSRange(location: 0, length: content.count),
+                                                          withTemplate: closePTag)
 
         content = filterNewLines(content)
 
@@ -199,9 +199,9 @@ import WordPressSharedObjC
         var content = string
 
         content = RegEx.styleAttr.stringByReplacingMatches(in: content,
-                                                                   options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.count),
-                                                                   withTemplate: "")
+                                                           options: .reportCompletion,
+                                                           range: NSRange(location: 0, length: content.count),
+                                                           withTemplate: "")
 
         return content
     }
@@ -302,11 +302,11 @@ import WordPressSharedObjC
         let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
         if let match = matches.first {
             let index = content.index(content.startIndex, offsetBy: match.range.location)
-#if swift(>=4.0)
+            #if swift(>=4.0)
             content = String(content.prefix(upTo: index))
-#else
+            #else
             content = content.substring(to: index)
-#endif
+            #endif
         }
 
         return content

--- a/Sources/WordPressShared/Utility/String+Helpers.swift
+++ b/Sources/WordPressShared/Utility/String+Helpers.swift
@@ -78,7 +78,7 @@ public extension String {
     /// Removes the prefix from the string that matches the given pattern, if any.
     ///
     /// Calling this method might invalidate any existing indices for use with this string.
-    /// 
+    ///
     /// - Parameters:
     ///     - pattern: The regular expression pattern to search for. Avoid using `^`.
     ///     - options: The options applied to the regular expression during matching.

--- a/Sources/WordPressShared/Utility/String+RemovingMatches.swift
+++ b/Sources/WordPressShared/Utility/String+RemovingMatches.swift
@@ -5,20 +5,20 @@ import WordPressSharedObjC
 #endif
 
 extension String {
-    
+
     /// Creates a new string by removing all matches of the specified regex.
     ///
     func removingMatches(pattern: String, options: NSRegularExpression.Options = []) -> String {
         let range = NSRange(location: 0, length: self.utf16.count)
         let regex: NSRegularExpression
-        
+
         do {
             regex = try NSRegularExpression(pattern: pattern, options: options)
         } catch {
             WPSharedLogError("Error parsing regex: \(error)")
             return self
         }
-        
+
         return regex.stringByReplacingMatches(in: self, options: .reportCompletion, range: range, withTemplate: "")
     }
 }

--- a/Sources/WordPressShared/Utility/String+StripShortcodes.swift
+++ b/Sources/WordPressShared/Utility/String+StripShortcodes.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 extension String {
-    
+
     /// Creates a new string by stripping all shortcodes from this string.
     ///
     func strippingShortcodes() -> String {
         let pattern = "\\[[^\\]]+\\]"
-        
+
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
 }

--- a/Sources/WordPressShared/Utility/String+URLValidation.swift
+++ b/Sources/WordPressShared/Utility/String+URLValidation.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 extension String {
-    
+
     /// This method can be used to check if the string contains a valid URL.
     ///
     /// - Returns: `true` if the string contains a valid string.  `false` otherwise.
     ///
     public func isValidURL() -> Bool {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        
+
         if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
             // it is a link, if the match covers the whole string
             return match.range.length == self.utf16.count

--- a/Sources/WordPressShared/Utility/WPImageURLHelper.swift
+++ b/Sources/WordPressShared/Utility/WPImageURLHelper.swift
@@ -6,7 +6,7 @@ open class WPImageURLHelper: NSObject {
      Adds to the provided url width and height parameters to allow the image to be resized on the server
 
      - parameter size: the required pixel size for the image.  If height is set to zero the
-                       returned image will have a height proportional to the requested width and vice versa.
+     returned image will have a height proportional to the requested width and vice versa.
      - parameter url:  the original url for the image
 
      - returns: an URL with the added query parameters.

--- a/Sources/WordPressShared/Views/WPStyleGuide+DynamicType.swift
+++ b/Sources/WordPressShared/Views/WPStyleGuide+DynamicType.swift
@@ -119,20 +119,20 @@ extension WPStyleGuide {
         ///     is changed in real time.  Creating a scaled font offers an alternative solution that works well
         ///     even in real time.
         let weightsThatNeedScaledFont: [UIFont.Weight] = [.black, .bold, .heavy, .semibold]
-        
+
         guard !weightsThatNeedScaledFont.contains(weight) else {
             return scaledFont(for: style, weight: weight)
         }
-        
+
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
 
-#if swift(>=4.0)
+        #if swift(>=4.0)
         let traits = [UIFontDescriptor.TraitKey.weight: weight]
         fontDescriptor = fontDescriptor.addingAttributes([.traits: traits])
-#else
+        #else
         let traits = [UIFontWeightTrait: weight]
         fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptorTraitsAttribute: traits])
-#endif
+        #endif
 
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
     }
@@ -163,7 +163,7 @@ extension WPStyleGuide {
         let fontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: defaultContentSizeCategory).pointSize
         return UIFont.systemFont(ofSize: fontSize, weight: weight)
     }
-    
+
     /// Created a scaled UIFont for the specified style and weight.  A scaled font will be resized Automatically
     /// by iOS to respond to dynamic type changes.
     ///

--- a/Sources/WordPressShared/Views/WPStyleGuide+SerifFonts.swift
+++ b/Sources/WordPressShared/Views/WPStyleGuide+SerifFonts.swift
@@ -28,13 +28,13 @@ extension WPStyleGuide {
         let fontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: defaultContentSizeCategory).pointSize
 
         guard #available(iOS 13, *),
-            let fontDescriptor = UIFont.systemFont(ofSize: fontSize, weight: weight).fontDescriptor.withDesign(.serif)  else {
-                switch weight {
-                    case .bold, .semibold, .heavy, .black:
-                        return WPStyleGuide.fixedBoldNotoFontWithSize(fontSize)
-                default:
-                        return WPStyleGuide.fixedNotoFontWithSize(fontSize)
-                }
+              let fontDescriptor = UIFont.systemFont(ofSize: fontSize, weight: weight).fontDescriptor.withDesign(.serif)  else {
+            switch weight {
+            case .bold, .semibold, .heavy, .black:
+                return WPStyleGuide.fixedBoldNotoFontWithSize(fontSize)
+            default:
+                return WPStyleGuide.fixedNotoFontWithSize(fontSize)
+            }
         }
 
         // Uses size from original font, so we don't want to override it here.

--- a/Tests/WordPressSharedTests/DebouncerTests.swift
+++ b/Tests/WordPressSharedTests/DebouncerTests.swift
@@ -42,7 +42,7 @@ class DebouncerTests: XCTestCase {
 
         wait(for: [debouncerHasRun], timeout: 0)
     }
-    
+
     /// Tests that we can cancel the debouncer's operation.
     ///
     func testDebouncerCanBeCancelled() {
@@ -50,14 +50,14 @@ class DebouncerTests: XCTestCase {
         let testTimeout = debouncerDelay * 2
         let debouncerHasRun = XCTestExpectation(description: "The debouncer's operation should be cancellable.")
         debouncerHasRun.isInverted = true
-        
+
         let debouncer = Debouncer(delay: debouncerDelay) {
             debouncerHasRun.fulfill()
         }
-        
+
         debouncer.call()
         debouncer.cancel()
-        
+
         wait(for: [debouncerHasRun], timeout: testTimeout)
     }
 

--- a/Tests/WordPressSharedTests/NSDateHelperTest.swift
+++ b/Tests/WordPressSharedTests/NSDateHelperTest.swift
@@ -7,12 +7,12 @@ class NSDateHelperTest: XCTestCase {
         let year: Int
         let month: Int
         let day: Int
-        
+
         var dateString: String {
             return "\(year)-\(month)-\(day)"
         }
     }
-    
+
     let data = Data(year: 2019, month: 02, day: 17)
     var date: Date?
     var dateFormatter: DateFormatter {
@@ -20,7 +20,7 @@ class NSDateHelperTest: XCTestCase {
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }
-    
+
     override func setUp() {
         NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
         date = dateFormatter.date(from: data.dateString)
@@ -61,17 +61,17 @@ class NSDateHelperTest: XCTestCase {
         let date = Date()
         let timeZone = TimeZone(secondsFromGMT: Calendar.current.timeZone.secondsFromGMT() - (60 * 60))
         XCTAssertEqual(date.toMediumString(inTimeZone: timeZone), "now")
-        
+
         let timeFormatter = DateFormatter()
         timeFormatter.dateStyle = .none
         timeFormatter.timeStyle = .short
         let withoutTimeZoneAdjust = timeFormatter.string(from: date)
-        
+
         XCTAssertEqual(date.mediumStringWithTime(), "Today, \(withoutTimeZoneAdjust)")
 
         timeFormatter.timeZone = timeZone
         let withTimeZoneAdjust = timeFormatter.string(from: date)
-        
+
         XCTAssertEqual(date.mediumStringWithTime(timeZone: timeZone), "Today, \(withTimeZoneAdjust)")
     }
 }

--- a/Tests/WordPressSharedTests/NSStringSummaryTests.swift
+++ b/Tests/WordPressSharedTests/NSStringSummaryTests.swift
@@ -6,27 +6,27 @@ class NSStringSummaryTests: XCTestCase {
     func testSummaryForContent() {
         let content = "<p>Lorem ipsum dolor sit amet, [shortcode param=\"value\"]consectetur[/shortcode] adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p> <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p><p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"
         let expectedSummary = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, …"
-        
+
         let summary = content.summarized()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testSummaryForContentWithGallery() {
         let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
         let expectedSummary = "Some Content"
-        
+
         let summary = content.summarized()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testSummaryForContentWithGallery2() {
         let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
         let expectedSummary = "Before\nAfter"
-        
+
         let summary = content.summarized()
-        
+
         XCTAssertEqual(summary, expectedSummary)
     }
 }

--- a/Tests/WordPressSharedTests/StringRemovingMatchesTests.swift
+++ b/Tests/WordPressSharedTests/StringRemovingMatchesTests.swift
@@ -2,34 +2,34 @@ import XCTest
 @testable import WordPressShared
 
 class StringRemovingMatchesTests: XCTestCase {
-    
+
     func testStringRemovingMatches() {
         let initial = "<p>Some Content</p>"
         let pattern = "<p>"
         let expected = "Some Content</p>"
-        
+
         let final = initial.removingMatches(pattern: pattern)
-        
+
         XCTAssertEqual(final, expected)
     }
-    
+
     func testStringRemovingMatchesWithEmojis() {
         let initial = "🌎world🌎"
         let pattern = "🌎"
         let expected = "world"
-        
+
         let final = initial.removingMatches(pattern: pattern)
-        
+
         XCTAssertEqual(final, expected)
     }
-    
+
     func testStringRemovingMatchesWithEmojis2() {
         let initial = "🌎world🌎"
         let pattern = "world"
         let expected = "🌎🌎"
-        
+
         let final = initial.removingMatches(pattern: pattern)
-        
+
         XCTAssertEqual(final, expected)
     }
 }

--- a/Tests/WordPressSharedTests/StringURLValidationTests.swift
+++ b/Tests/WordPressSharedTests/StringURLValidationTests.swift
@@ -2,15 +2,15 @@ import XCTest
 @testable import WordPressShared
 
 class StringURLValidationTests: XCTestCase {
-    
+
     // MARK: - Invalid URLs
-    
+
     func testInvalidURLs() {
         let urls = [
             "invalidurl",
             "123123",
             "wwwwordpresscom"]
-        
+
         for url in urls {
             guard !url.isValidURL() else {
                 XCTFail("\(url) is valid (expected invalid).")
@@ -27,7 +27,7 @@ class StringURLValidationTests: XCTestCase {
             "https://localhost",
             "www.wordpress.com",
             "http://www.wordpress.com"]
-        
+
         for url in urls {
             guard url.isValidURL() else {
                 XCTFail("\(url) is invalid (expected valid).")


### PR DESCRIPTION
Builds on top of https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/344 and addresses all the SwiftLint violations via:

```
<local DerivedData path>/WordPress-iOS-Shared/SourcePackages/artifacts/swiftlint/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-0.54.0-macos/bin/swiftlint /
  lint --fix --format
```

I decided to split the PRs so that the one setting up the tooling didn't have any noise from the fixes and also worked as a demo for how the integration picks up violations in CI.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
