### PR TITLE
RFC: Load SwiftLint version in the Package Description

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.5
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -14,7 +15,7 @@ let package = Package(
         // See https://github.com/erikdoe/ocmock/issues/500#issuecomment-1002700625
         .package(url: "https://github.com/erikdoe/ocmock", revision: "afd2c6924e8a36cb872bc475248b978f743c6050"),
         .package(url: "https://github.com/Quick/Quick", from: "6.0.0"),
-        .package(url: "https://github.com/realm/SwiftLint", from: "0.54.0")
+        .package(url: "https://github.com/realm/SwiftLint", .exactItem(loadSwiftLintVersion()))
     ],
     targets: [
         .target(
@@ -60,3 +61,25 @@ let package = Package(
         ),
     ]
 )
+
+func loadSwiftLintVersion() -> Version {
+    guard let yamlString = try? String(contentsOf: URL(fileURLWithPath: #file)
+                                        .deletingLastPathComponent()
+                                        .appendingPathComponent(".swiftlint.yml")) else {
+        fatalError("Failed to read YAML file.")
+    }
+    
+    guard let versionLine = yamlString.components(separatedBy: .newlines)
+            .first(where: { $0.contains("swiftlint_version") }) else {
+        fatalError("SwiftLint version not found in YAML file.")
+    }
+    
+    // assumes the format `swiftlint_version: <version>`
+    guard let version = Version(versionLine.components(separatedBy: ":")
+                                    .last?
+                                    .trimmingCharacters(in: .whitespaces) ?? "") else {
+        fatalError("Failed to extract SwiftLint version.")
+    }
+    
+    return version
+}

--- a/Package.swift
+++ b/Package.swift
@@ -64,20 +64,20 @@ let package = Package(
 
 func loadSwiftLintVersion() -> Version {
     guard let yamlString = try? String(contentsOf: URL(fileURLWithPath: #file)
-                                        .deletingLastPathComponent()
-                                        .appendingPathComponent(".swiftlint.yml")) else {
+        .deletingLastPathComponent()
+        .appendingPathComponent(".swiftlint.yml")) else {
         fatalError("Failed to read YAML file.")
     }
 
     guard let versionLine = yamlString.components(separatedBy: .newlines)
-            .first(where: { $0.contains("swiftlint_version") }) else {
+        .first(where: { $0.contains("swiftlint_version") }) else {
         fatalError("SwiftLint version not found in YAML file.")
     }
 
-    // assumes the format `swiftlint_version: <version>`
+    // Assumes the format `swiftlint_version: <version>`
     guard let version = Version(versionLine.components(separatedBy: ":")
-                                    .last?
-                                    .trimmingCharacters(in: .whitespaces) ?? "") else {
+        .last?
+        .trimmingCharacters(in: .whitespaces) ?? "") else {
         fatalError("Failed to extract SwiftLint version.")
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -68,18 +68,18 @@ func loadSwiftLintVersion() -> Version {
                                         .appendingPathComponent(".swiftlint.yml")) else {
         fatalError("Failed to read YAML file.")
     }
-    
+
     guard let versionLine = yamlString.components(separatedBy: .newlines)
             .first(where: { $0.contains("swiftlint_version") }) else {
         fatalError("SwiftLint version not found in YAML file.")
     }
-    
+
     // assumes the format `swiftlint_version: <version>`
     guard let version = Version(versionLine.components(separatedBy: ":")
                                     .last?
                                     .trimmingCharacters(in: .whitespaces) ?? "") else {
         fatalError("Failed to extract SwiftLint version.")
     }
-    
+
     return version
 }


### PR DESCRIPTION
This PR is a simple experiment on loading the right SwiftLint version defined in `.swiftlint.yml` in the Package Description.
I have refrained from using a proper YAML parser to keep it simple, so I just load the file and parse it as a string.

I don't have many ideas on sharing this code to use in other repos, but perhaps it also isn't a big deal to replicate it as needed.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
