### PR TITLE
Remove Gutenberg Video block from excerpt to hide VideoPress URLs

### DIFF
--- a/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
+++ b/Sources/WordPressShared/Utility/String+StripGutenbergContentForExcerpt.swift
@@ -19,10 +19,10 @@ extension String {
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }
 
-    /// Strips Gutenberg VideoPress block.
+    /// Strips VideoPress references from Gutenberg VideoPress and Video blocks.
     ///
     private func strippingGutenbergVideoPress() -> String {
-        let pattern = "(?s)\n?<!--\\swp:videopress/video?(.*?)wp:videopress/video\\s-->"
+        let pattern = "(?s)\n?<!--\\swp:video.*?(.*?)wp:video.*?\\s-->"
 
         return removingMatches(pattern: pattern, options: .caseInsensitive)
     }

--- a/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -38,4 +38,13 @@ class StringStripGutenbergContentForExcerptTests: XCTestCase {
 
         XCTAssertEqual(summary, expectedSummary)
     }
+    
+    func testStrippingGutenbergContentForExcerptWithVideoPress2() {
+            let content = "<p>Before</p>\n<!-- wp:video {\"guid\":\"AbCDe\",\"id\":5297} -->\n<figure class=\"wp-block-video\"><div class=\"wp-block-embed__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:video -->\n<p>After</p>"
+            let expectedSummary = "<p>Before</p>\n<p>After</p>"
+
+            let summary = content.strippingGutenbergContentForExcerpt()
+
+            XCTAssertEqual(summary, expectedSummary)
+        }
 }

--- a/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
+++ b/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift
@@ -38,7 +38,7 @@ class StringStripGutenbergContentForExcerptTests: XCTestCase {
 
         XCTAssertEqual(summary, expectedSummary)
     }
-    
+
     func testStrippingGutenbergContentForExcerptWithVideoPress2() {
             let content = "<p>Before</p>\n<!-- wp:video {\"guid\":\"AbCDe\",\"id\":5297} -->\n<figure class=\"wp-block-video\"><div class=\"wp-block-embed__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:video -->\n<p>After</p>"
             let expectedSummary = "<p>Before</p>\n<p>After</p>"


### PR DESCRIPTION
Fixes the iOS side of https://github.com/wordpress-mobile/gutenberg-mobile/issues/6669

-----

## Description:

Following the implementation of VideoPress v5, media uploaded to the video block on supported sites will automatically convert to VideoPress. This has led to VideoPress URLs being visible alongside excerpts in the post list section. 

To remove all references to VideoPress from the post excerpt, this PR extends the `strippingGutenbergVideoPress ` function to include video blocks. 

See https://github.com/wordpress-mobile/WordPress-iOS/pull/22713 for the main iOS companion to this PR.

-----

## To Test:

1. In the app, select a WordPress.com site to edit and open the post editor.
2. Add the Video block and go through the steps to add a video.
3. Save your changes and return to the post list.
4. Verify the VideoPress URL does not display in the post list.

-----

## Screenshots:

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/wordpress-mobile/WordPress-iOS-Shared/assets/2998162/30b533e4-19ac-40be-886b-01ad63464a86" width="100%"> | <img src="https://github.com/wordpress-mobile/WordPress-iOS-Shared/assets/2998162/9b8b6b8a-a094-4aac-a3af-d373d47ecb24" width="100%"> |

-----

## Regression Notes:

1. Potential unintended areas of impact

    - As we're making changes to the regex that filters out the VideoPress block from the excerpt, there is a chance this PR could unintentionally change the existing functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - I manually tested the changes and relied on [the existing test](https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/d9d8d04cd36a0d79539e2f5c1348ae68c911fd03/Tests/WordPressSharedTests/StringStripGutenbergContentForExcerptTests.swift#L33-L40) that verifies VideoPress blocks remain correctly hidden. 

3. What automated tests I added (or what prevented me from doing so)

    - I added a new test in https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/352/commits/d9d8d04cd36a0d79539e2f5c1348ae68c911fd03 that verifies regular video blocks are removed from the post excerpt.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
