### PR TITLE
Bump version to 2.3.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,7 @@ steps:
     plugins: *common_plugins
 
   - label: ":swift: SwiftLint"
+    key: "swiftlint"
     command: run_swiftlint --strict
     plugins: *common_plugins
     notify:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 2.3.1
+
+### Bug Fixes
+
+- Remove video block content from post excerpt [#352]
+
 ## 2.3.0
 
 ### New Features

--- a/WordPressShared.podspec
+++ b/WordPressShared.podspec
@@ -4,7 +4,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressShared'
-  s.version       = '2.3.0'
+  s.version       = '2.3.1'
 
   s.summary       = 'Shared components used in building the WordPress iOS apps and other library components.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 24.4 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.